### PR TITLE
ci: fix broken action pins and gitleaks permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,11 +64,15 @@ jobs:
   secrets:
     name: Secrets scan
     runs-on: ubuntu-latest
+    # gitleaks-action lists PR commits via the API; default token needs this on private repos
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: .gitleaks.toml
@@ -86,11 +90,11 @@ jobs:
             p/python
             p/secrets
       - name: OSV-Scanner (SCA)
-        uses: google/osv-scanner-action@v2
+        # Root action.yml has no runs:; use the nested scanner action + concrete tag
+        uses: google/osv-scanner-action/osv-scanner-action@v2.3.8
         with:
           scan-args: |-
             --recursive
-            --skip-git
             .
 
   trivy:
@@ -99,7 +103,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Trivy filesystem scan
-        uses: aquasecurity/trivy-action@0.29.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: fs
           exit-code: "1"
@@ -116,6 +120,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: trufflesecurity/trufflehog@v3
+      - uses: trufflesecurity/trufflehog@v3.96.0
         with:
           extra_args: --only-verified --exclude-paths=.trufflehog-exclude

--- a/.github/workflows/code-review-graph.yml
+++ b/.github/workflows/code-review-graph.yml
@@ -12,6 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: tirth8205/code-review-graph@v2
+      - uses: tirth8205/code-review-graph@v2.3.7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Pin Trivy/OSV/TruffleHog to resolvable tags (and use the nested OSV scanner action path)
- Drop removed `--skip-git` OSV flag
- Grant gitleaks `pull-requests: read` and bump to `@v3` so PR commit listing works on this private repo

## Test plan
- [ ] CI green on this PR (secrets, SAST, Trivy, TruffleHog jobs resolve and run)
- [ ] Confirm no regressions in already-passing jobs (repo lint, static analysis, CLI tests)


Made with [Cursor](https://cursor.com)