### PR TITLE
fix: scanner console, Realtime dashboard, Snyk skills CLI, and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,17 +10,19 @@
 # Prefer `modal token new` / CLI login over embedding tokens when possible.
 # MODAL_TOKEN_ID=
 # MODAL_TOKEN_SECRET=
-# HTTP API URL from Supabase → Project Settings → API (https://<ref>.supabase.co).
-# Do NOT put the postgresql:// URI here — that belongs in SUPABASE_DB_URL for schema apply / psql.
-SUPABASE_URL=
-SUPABASE_SERVICE_ROLE_KEY=
+
 # Anon/public key — safe for browser use (RLS-gated reads only).
 # Used by: prototypes/dc-dashboard Live mode via ./scripts/sync-dashboard-config.sh
 # (writes gitignored tripwire-dashboard.config.js). Or skip anon and use
 # node scripts/serve-dashboard.mjs (127.0.0.1 proxy; never puts service_role in the browser).
 # Get from: Supabase → Project Settings → API → anon / public.
 SUPABASE_ANON_KEY=
+# HTTP API URL from Supabase → Project Settings → API (https://<ref>.supabase.co).
+# Do NOT put the postgresql:// URI here — that belongs in SUPABASE_DB_URL for schema apply / psql.
+SUPABASE_URL=
+SUPABASE_SERVICE_ROLE_KEY=
 # Required for first-run DDL (`tripwire setup` / auto on first scan). Not used by Modal HTTP clients.
+# Re-run `tripwire setup --force` after pulling schema.sql changes (console columns, Realtime).
 # Prefer Session pooler URI if Direct `db.<ref>.supabase.co` does not resolve (ENOTFOUND).
 # Format examples (pick one, uncomment, fill):
 #   postgresql://postgres:...@db.<ref>.supabase.co:5432/postgres         (Direct)

--- a/README.md
+++ b/README.md
@@ -18,8 +18,20 @@ AI skill / MCP server security scanning platform.
 Local build notes (gitignored): `internal-docs/00_build/security-scanning-platform-spec.md`
 and `internal-docs/00_build/build-day-decisions.md`.
 
+## Who is this for?
+
+| Persona | Start here |
+|---------|------------|
+| See it in 2 minutes | [prototypes/README.md](prototypes/README.md) (Mock dashboard) |
+| Scan my skills/MCP | [Setup](#setup) → `tripwire scan --dry-discover` |
+| Run the full platform | [Setup](#setup) + [fixtures/README.md](fixtures/README.md) |
+| Operate Modal/Supabase | [.env.example](.env.example) + [OPTIONAL_SCANNER_KEYS.md](fixtures/OPTIONAL_SCANNER_KEYS.md) |
+| Contribute | [CONTRIBUTING.md](CONTRIBUTING.md) |
+| Compliance / audit | [prototypes/README.md](prototypes/README.md) + [fixtures/README.md](fixtures/README.md) |
+| Security reporter | [SECURITY.md](SECURITY.md) |
+
 ## Layout
-- `db/schema.sql` — Postgres/Supabase DDL + rollup; anon SELECT for Live dashboard.
+- `db/schema.sql` — Postgres/Supabase DDL + rollup; anon SELECT + Realtime publication for Live dashboard.
 - `cli/` — `tripwire` Node CLI (discovery, hashing, idempotency, bootstrap, Modal spawn).
 - `sandbox/` — Modal app + adapters; host packs dirs, sandbox extracts.
 - `scripts/` — setup (Supabase/Modal), `serve-dashboard.mjs`, hygiene gates.
@@ -48,13 +60,15 @@ Intentional vuln fixtures under `fixtures/` and mock data under `prototypes/` ar
 # Optional for direct browser Live dashboard: SUPABASE_ANON_KEY (or use serve-dashboard.mjs)
 
 cd cli && npm install && npm link   # gives you the `tripwire` command locally
-npm test                            # discovery + hashing + schema probe + --force unit tests (17)
+npm test                            # discovery + hashing + schema probe + --force unit tests (18)
 
 # First-run DB bootstrap (also runs automatically on the first real `tripwire scan`):
 tripwire setup                      # or: ./scripts/setup-supabase.sh
 # Needs SUPABASE_DB_URL (postgresql://) to apply DDL; HTTP URL alone cannot.
 # If db.<ref>.supabase.co does not resolve, use the Session pooler URI from
 # Supabase → Project Settings → Database (and confirm the project is not paused).
+# Re-run `tripwire setup --force` after pulling schema changes (console columns,
+# Realtime publication) — probe also checks scan_run_scanners.completed_at exists.
 
 # sandbox side (Modal) — fill scanner keys in .env as needed
 pip install modal
@@ -78,18 +92,25 @@ tripwire scan ./fixtures/mcp/mcp_manifest.json
 needs Supabase (auto-bootstrapped on first scan / `tripwire setup`) + a deployed sandbox.
 
 ## What's real vs stubbed
-- **IMPLEMENTED:** full schema + rollup function + anon SELECT policies/GRANTs; CLI
+- **IMPLEMENTED:** full schema + rollup function + anon SELECT policies/GRANTs + Realtime
+  publication on `scan_runs` / `scan_run_scanners` / `findings`; `scan_run_scanners`
+  incremental writes from Modal (`running` placeholders, `console_output`,
+  `started_at`/`completed_at`; PGRST204-safe fallback when columns missing); CLI
   discovery/hashing/idempotency/batching; `tripwire setup` / first-scan schema bootstrap
-  (`cli/src/ensureSchema.js`); `./scripts/setup-modal.sh` secret sync + deploy; scanner
-  adapters shell out to the actual upstream CLIs (`skill-scanner`, `mcp-scanner`,
-  `snyk-agent-scan`, `tessl`) with real flags and parse their documented output shapes;
-  fixture set under `fixtures/` (see `fixtures/README.md`); `_acquire_target` dispatch
-  (git clone, local copy, host→sandbox tar upload via `local_entrypoint`, MCP
-  introspection-only empty workdir); dashboard Live/Mock + `serve-dashboard.mjs` /
-  `sync-dashboard-config.sh`.
-- **VERIFIED (unit):** `cd cli && npm test` — 17 pass (discovery, content-hash, schema-probe, `--force`);
-  `pytest sandbox/test_acquire_target.py` — 30 pass; `cd prototypes/dc-dashboard && npm test`
-  — 9 pass (Live gating / chip copy; optional Live smoke skipped without config).
+  (`cli/src/ensureSchema.js`, probes `completed_at` column); `./scripts/setup-modal.sh`
+  secret sync + deploy; scanner adapters shell out to the actual upstream CLIs
+  (`skill-scanner`, `mcp-scanner`, `snyk-agent-scan`, `tessl`) with real flags and parse
+  their documented output shapes; fixture set under `fixtures/` (see `fixtures/README.md`);
+  `_acquire_target` dispatch (git clone, local copy, host→sandbox tar upload via
+  `local_entrypoint`, MCP introspection-only empty workdir); dashboard Live/Mock with
+  Supabase Realtime (~1s) + 8s poll fallback, SCANNING in-flight UI, scanner console
+  output in drawer, partial-failed “n out of m scanners unreachable” copy;
+  `serve-dashboard.mjs` / `sync-dashboard-config.sh`.
+- **VERIFIED (unit):** `cd cli && npm test` — 18 pass (discovery, content-hash,
+  schema-probe incl. `completed_at`, `--force`); `pytest sandbox/test_acquire_target.py`
+  — 30 pass; `cd prototypes/dc-dashboard && npm test` — 36 pass, 1 skipped (Live
+  gating, Realtime wiring, SCANNING/console/unreachable mapping; optional Live smoke
+  skipped without config).
 - **VERIFIED (operator, 2026-08-01):** Modal secrets + `tripwire-scan` deploy with
   `scanners` packaged (`add_local_python_source(..., copy=True)`); host tar packing
   (`modal run sandbox/scan_app.py` → `[acquire] packed …`) delivers fixture `SKILL.md` to

--- a/cli/src/ensureSchema.js
+++ b/cli/src/ensureSchema.js
@@ -10,22 +10,34 @@ export function schemaPath() {
   return join(dirname(fileURLToPath(import.meta.url)), '../../db/schema.sql');
 }
 
-/** True when PostgREST/Postgres says the tripwire tables are missing. */
+/** True when PostgREST/Postgres says tables or columns are missing. */
 export function isMissingSchemaError(error) {
   if (!error) return false;
   const blob = `${error.code || ''} ${error.message || ''} ${error.details || ''}`;
-  return /PGRST205|could not find the table|relation ["'].*["'] does not exist|schema cache/i.test(blob);
+  return /PGRST20[45]|could not find the (table|.*column)|relation ["'].*["'] does not exist|schema cache/i.test(blob);
 }
 
 /**
- * Probe via HTTP API whether `items` is queryable.
+ * Probe via HTTP API whether core tables and migration columns are queryable.
+ * Checks both `items` (table existence) and `scan_run_scanners.completed_at`
+ * (column-level migration), so `ensureSchema --force` is triggered when the
+ * DB has stale columns.
  * @returns {'ready'|'missing'}
  */
 export async function probeSchema(supabase = getSupabase()) {
-  const { error } = await supabase.from('items').select('id').limit(1);
-  if (!error) return 'ready';
-  if (isMissingSchemaError(error)) return 'missing';
-  throw new Error(`Supabase probe failed: ${error.message || error.code || 'unknown error'}`);
+  const { error: itemsErr } = await supabase.from('items').select('id').limit(1);
+  if (itemsErr) {
+    if (isMissingSchemaError(itemsErr)) return 'missing';
+    throw new Error(`Supabase probe failed: ${itemsErr.message || itemsErr.code || 'unknown error'}`);
+  }
+
+  const { error: colErr } = await supabase
+    .from('scan_run_scanners')
+    .select('completed_at')
+    .limit(1);
+  if (colErr && isMissingSchemaError(colErr)) return 'missing';
+
+  return 'ready';
 }
 
 export async function applySchema({ dbUrl = process.env.SUPABASE_DB_URL } = {}) {

--- a/cli/test/ensureSchema.test.js
+++ b/cli/test/ensureSchema.test.js
@@ -19,3 +19,14 @@ test('isMissingSchemaError detects PostgREST missing-table shapes', () => {
   assert.equal(isMissingSchemaError({ message: 'JWT expired' }), false);
   assert.equal(isMissingSchemaError(null), false);
 });
+
+test('isMissingSchemaError detects PGRST204 missing-column errors', () => {
+  assert.equal(
+    isMissingSchemaError({ code: 'PGRST204', message: "Could not find the 'completed_at' column of 'scan_run_scanners' in the schema cache" }),
+    true
+  );
+  assert.equal(
+    isMissingSchemaError({ message: "Could not find the 'console_output' column of 'scan_run_scanners' in the schema cache" }),
+    true
+  );
+});

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -48,12 +48,25 @@ create table if not exists scan_run_scanners (
   id             uuid primary key default gen_random_uuid(),
   scan_run_id    uuid not null references scan_runs(id),
   scanner_source text not null,
-  status         text not null check (status in ('completed','skipped_missing_credential','unreachable','not_applicable')),
+  status         text not null check (status in ('running','completed','failed','skipped_missing_credential','unreachable','not_applicable')),
   checks_run     integer,
-  detail         text  -- optional stderr / reason (e.g. unreachable engines)
+  detail         text,  -- human-readable summary (e.g. "3 checks — 1 finding (red): injection")
+  console_output text,  -- raw stdout/stderr from scanner subprocess (truncated)
+  started_at     timestamptz,
+  completed_at   timestamptz
 );
--- Additive for DBs created before `detail` existed:
+-- Additive migrations for DBs created before these columns existed:
 alter table scan_run_scanners add column if not exists detail text;
+alter table scan_run_scanners add column if not exists console_output text;
+alter table scan_run_scanners add column if not exists started_at timestamptz;
+alter table scan_run_scanners add column if not exists completed_at timestamptz;
+-- Widen status enum for existing DBs (idempotent: no-op if already correct).
+do $$ begin
+  alter table scan_run_scanners drop constraint if exists scan_run_scanners_status_check;
+  alter table scan_run_scanners add constraint scan_run_scanners_status_check
+    check (status in ('running','completed','failed','skipped_missing_credential','unreachable','not_applicable'));
+exception when others then null;
+end $$;
 
 create table if not exists findings (
   id                 uuid primary key default gen_random_uuid(),
@@ -185,3 +198,23 @@ begin
   update scan_runs set risk_score = v_risk where id = v_latest_run_id;
 end;
 $$ language plpgsql;
+
+-- ─── Supabase Realtime ──────────────────────────────────────────────────────
+-- Enable Realtime publication so the browser dashboard receives INSERT/UPDATE
+-- events within ~1s of Modal writing scanner results (replaces 8s polling).
+-- The supabase_realtime publication already exists on Supabase-hosted projects.
+-- Run once in the SQL Editor or via `psql`.
+do $$ begin
+  alter publication supabase_realtime add table scan_runs;
+exception when others then null;
+end $$;
+
+do $$ begin
+  alter publication supabase_realtime add table scan_run_scanners;
+exception when others then null;
+end $$;
+
+do $$ begin
+  alter publication supabase_realtime add table findings;
+exception when others then null;
+end $$;

--- a/prototypes/README.md
+++ b/prototypes/README.md
@@ -14,13 +14,15 @@ A **status chip** appears next to the data-source dropdown on the **Guard** tab,
 
 Status chip meanings:
 
-- **Live · Supabase** — items loaded from Supabase
+- **Live · Realtime** — Supabase Realtime subscribed; updates within ~1s of Modal writes
+- **Live · Supabase** — items loaded from Supabase (poll-only or initial load)
 - **Live · empty** — connected; 0 items (not demo data)
 - **Demo data** — Mock selected
 - **Missing API key** — Live selected but browser config has no usable key (shows demo data)
 - **Connection error** — configured but fetch failed (shows demo data)
 
-There is no “fallback…” chip wording.
+There is no “fallback…” chip wording. When Realtime is unavailable, in-flight scans still
+refresh via an **8s poll** (or 30s while Realtime is connected and a run is `running`).
 
 ### Why you may see “Live” + “Missing API key”
 
@@ -50,14 +52,27 @@ cd prototypes/dc-dashboard && python3 -m http.server 8765
 
 If the chip says **Missing API key**, `tripwire-dashboard.config.js` has URL but an empty anon key — Live never calls Supabase. Set anon + sync, or use `serve-dashboard.mjs`.
 
-Also run `tripwire setup --force` once so anon SELECT policies + GRANTs from `db/schema.sql` are applied.
+Also run `tripwire setup --force` once so anon SELECT policies + GRANTs + Realtime
+publication from `db/schema.sql` are applied. The CLI probe also checks
+`scan_run_scanners.completed_at` — stale DBs without console/timestamp columns trigger
+re-apply on the next setup or first scan.
 
 **Never put `service_role` in the browser config.**
+
+### In-flight scans (Live)
+
+While Modal writes results, cards show **SCANNING** (execution status wins over stale
+heatmap). Open a card’s scanner drawer to see per-engine progress, **Modal console
+output** (`console_output`), and durations from `started_at`/`completed_at`. Partial
+failures surface copy like “**n out of m scanners unreachable — risk from completed
+engines**”. Without the schema migration, scans still complete but console columns and
+Realtime may be absent (Modal falls back to legacy-safe inserts).
 
 ## Database bootstrap
 
 ```bash
 tripwire setup                 # or ./scripts/setup-supabase.sh
+tripwire setup --force         # re-apply after schema.sql changes (console + Realtime)
 ```
 
 Requires `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, and `SUPABASE_DB_URL` in `.env`.
@@ -68,7 +83,10 @@ Requires `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, and `SUPABASE_DB_URL` in `
 cd prototypes/dc-dashboard && npm test
 ```
 
-Covers Live config gating, mocked Supabase table fetches, item mapping, empty vs error sources, and chip copy. Optional Live smoke runs only when `tripwire-dashboard.config.js` has a real URL + key (skipped otherwise — not a CI failure).
+Covers Live config gating, mocked Supabase fetches, SCANNING/in-flight mapping,
+console output relay, Realtime module wiring, unreachable partial-failed copy, and chip
+labels. Optional Live smoke runs only when `tripwire-dashboard.config.js` has a real URL
++ key (skipped otherwise — not a CI failure). `npm test` — 36 pass, 1 skipped.
 
 ---
 

--- a/prototypes/dc-dashboard/Tripwire.dc.html
+++ b/prototypes/dc-dashboard/Tripwire.dc.html
@@ -248,7 +248,15 @@
             </div>
           </sc-if>
 
-          <div style="font-family:var(--font-mono);font-size:10px;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;margin:16px 0 8px">Scanner outputs ({{ selectedView.scannersView.length }})</div>
+          <div style="font-family:var(--font-mono);font-size:10px;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;margin:16px 0 8px">Scanner outputs ({{ selectedView.scannersViewLabel }})</div>
+          <sc-if value="{{ selectedView.scanningPlaceholder }}">
+            <div style="background:var(--bg-base);border:1px solid var(--border-subtle);border-left:3px solid var(--accent);border-radius:6px;padding:12px 14px;margin-bottom:6px">
+              <div style="color:var(--accent);animation:pulse 1.5s ease-in-out infinite;font-size:12px;margin-bottom:4px">◌ Scan in progress — waiting for Modal scanner output…</div>
+              <sc-if value="{{ selectedView.scanStartedAtLabel }}">
+                <div style="font-family:var(--font-mono);font-size:10px;color:var(--text-muted)">Started {{ selectedView.scanStartedAtLabel }}</div>
+              </sc-if>
+            </div>
+          </sc-if>
           <sc-for list="{{ selectedView.scannersView }}" as="scv" hint-placeholder-count="2">
             <div style="background:var(--bg-base);border:1px solid var(--border-subtle);border-left:3px solid {{ scv.statusColor }};border-radius:6px;margin-bottom:6px;overflow:hidden">
               <div onClick="{{ scv.onToggle }}" style="display:flex;align-items:center;justify-content:space-between;padding:8px 10px;cursor:pointer;gap:8px;user-select:none;transition:background 150ms">
@@ -268,6 +276,9 @@
               </div>
               <sc-if value="{{ scv.expanded }}">
                 <div style="border-top:1px solid var(--border-subtle);padding:8px 10px 10px 30px;font-size:11px;color:var(--text-secondary)">
+                  <sc-if value="{{ scv.isRunning }}">
+                    <div style="color:var(--accent);margin-bottom:6px;animation:pulse 1.5s ease-in-out infinite">◌ Scanner running on Modal sandbox…</div>
+                  </sc-if>
                   <sc-if value="{{ scv.output.raw_summary }}">
                     <div style="margin-bottom:6px;color:var(--text-primary)">{{ scv.output.raw_summary }}</div>
                   </sc-if>
@@ -279,6 +290,10 @@
                   </sc-if>
                   <sc-if value="{{ scv.output.quality_score }}">
                     <div style="margin-bottom:6px">Quality score: <span style="color:var(--accent);font-family:var(--font-mono);font-weight:600">{{ scv.output.quality_score }}</span>/100</div>
+                  </sc-if>
+                  <sc-if value="{{ scv.output.console_output }}">
+                    <div style="font-family:var(--font-mono);font-size:10px;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;margin:6px 0 4px">Modal console output</div>
+                    <div style="font-family:var(--font-mono);font-size:10px;background:var(--bg-deep);padding:6px 8px;border-radius:4px;color:#8fe388;overflow-x:auto;white-space:pre-wrap;max-height:200px;overflow-y:auto;line-height:1.5">{{ scv.output.console_output }}</div>
                   </sc-if>
                   <sc-if value="{{ scv.findingsForScanner.length }}">
                     <div style="font-family:var(--font-mono);font-size:10px;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;margin:6px 0 4px">Findings from this scanner</div>
@@ -414,7 +429,8 @@ class Component extends DCLogic {
     searchQuery: '',
     sortKey: 'name',
     sortDir: 'asc',
-    expandedScanners: {}
+    expandedScanners: {},
+    realtimeConnected: false
   };
 
   componentDidMount() {
@@ -440,16 +456,70 @@ class Component extends DCLogic {
 
   _managePoll(data, mode) {
     clearInterval(this._pollTimer);
+    this._teardownRealtime();
     if (mode !== 'live') return;
+
+    const cfg = window.__TRIPWIRE_CONFIG;
+    if (cfg?.SUPABASE_URL && cfg?.SUPABASE_ANON_KEY) {
+      this._tryRealtime(cfg, data);
+      return;
+    }
+    this._startPollFallback(data);
+  }
+
+  _tryRealtime(cfg, data) {
+    import('./tripwire-realtime.js').then(rt => {
+      this._rt = rt;
+      return rt.subscribe(cfg, (payload) => {
+        console.info('[tripwire] realtime event:', payload.eventType, payload.table);
+        this._reloadLive();
+      });
+    }).then(status => {
+      if (status === 'SUBSCRIBED') {
+        console.info('[tripwire] Realtime connected — 8s polling disabled');
+        this.setState({ realtimeConnected: true });
+        const hasRunning = data?.items?.some(it => it.status === 'running');
+        if (hasRunning) {
+          this._pollTimer = setInterval(() => this._reloadLive(), 30000);
+        }
+      } else {
+        console.warn('[tripwire] Realtime unavailable — falling back to 8s poll');
+        this._startPollFallback(data);
+      }
+    }).catch(err => {
+      console.warn('[tripwire] Realtime init failed:', err?.message, '— using 8s poll');
+      this._startPollFallback(data);
+    });
+  }
+
+  _startPollFallback(data) {
+    clearInterval(this._pollTimer);
     const hasRunning = data && data.items && data.items.some(it => it.status === 'running');
     if (!hasRunning) return;
     this._pollTimer = setInterval(() => {
       import('./tripwire-live.js').then(m => m.default('live')).then(result => {
         this.setState({ data: result.data, dataSource: result.source });
         const stillRunning = result.data && result.data.items && result.data.items.some(it => it.status === 'running');
-        if (!stillRunning) clearInterval(this._pollTimer);
+        if (!stillRunning && !this._rt) clearInterval(this._pollTimer);
       }).catch(() => {});
     }, 8000);
+  }
+
+  _reloadLive() {
+    const now = Date.now();
+    if (this._lastReload && now - this._lastReload < 2000) return;
+    this._lastReload = now;
+    import('./tripwire-live.js').then(m => m.default('live')).then(result => {
+      this.setState({ data: result.data, dataSource: result.source });
+    }).catch(() => {});
+  }
+
+  _teardownRealtime() {
+    if (this._rt) {
+      this._rt.unsubscribe();
+      this._rt = null;
+    }
+    this.setState({ realtimeConnected: false });
   }
 
   setDataSourceMode = (e) => {
@@ -462,6 +532,10 @@ class Component extends DCLogic {
   componentWillUnmount() {
     clearInterval(this._cliTimer);
     clearInterval(this._pollTimer);
+    if (this._rt) {
+      this._rt.unsubscribe();
+      this._rt = null;
+    }
   }
 
   setTab = (t) => this.setState({ activeTab: t });
@@ -590,6 +664,7 @@ class Component extends DCLogic {
     const kit = this._statusKit;
     if (kit?.scannerExecMeta) return kit.scannerExecMeta(st);
     const fallback = {
+      running: { color: '#4da2ff', label: '◌ Running' },
       completed: { color: '#34d399', label: '✓ Completed' },
       skipped_missing_credential: { color: '#6b7a8e', label: '⊘ Skipped' },
       unreachable: { color: '#a78bfa', label: '✗ Unreachable' },
@@ -626,14 +701,16 @@ class Component extends DCLogic {
 
     const dataSourceChips = {
       loading: { label: 'Loading…', dotColor: '#6b7a8e', textColor: '#8fa3be', bgColor: 'rgba(107,122,142,0.1)', borderColor: '#192638', tooltip: 'Checking data source…' },
-      live: { label: 'Live · Supabase', dotColor: '#34d399', textColor: '#34d399', bgColor: 'rgba(52,211,153,0.1)', borderColor: 'rgba(52,211,153,0.3)', tooltip: 'Fetching real data from Supabase' },
+      live: { label: 'Live · Supabase', dotColor: '#34d399', textColor: '#34d399', bgColor: 'rgba(52,211,153,0.1)', borderColor: 'rgba(52,211,153,0.3)', tooltip: 'Fetching real data from Supabase (polling)' },
+      'live-realtime': { label: 'Live · Realtime', dotColor: '#34d399', textColor: '#34d399', bgColor: 'rgba(52,211,153,0.15)', borderColor: 'rgba(52,211,153,0.4)', tooltip: 'Supabase Realtime — updates arrive within ~1s of Modal writes' },
       'live-empty': { label: 'Live · empty', dotColor: '#f59e0b', textColor: '#f59e0b', bgColor: 'rgba(245,158,11,0.1)', borderColor: 'rgba(245,158,11,0.3)', tooltip: 'Connected to Supabase — no items yet' },
       'mock-selected': { label: 'Demo data', dotColor: '#6b7a8e', textColor: '#8fa3be', bgColor: 'rgba(107,122,142,0.1)', borderColor: '#192638', tooltip: 'Using built-in demo data (user selected)' },
       mock: { label: 'Missing API key', dotColor: '#f59e0b', textColor: '#f59e0b', bgColor: 'rgba(245,158,11,0.1)', borderColor: 'rgba(245,158,11,0.3)', tooltip: 'Run: node scripts/serve-dashboard.mjs  (or set SUPABASE_ANON_KEY + ./scripts/sync-dashboard-config.sh)' },
       'mock-failed': { label: 'Connection error', dotColor: '#f43f5e', textColor: '#f43f5e', bgColor: 'rgba(244,63,94,0.1)', borderColor: 'rgba(244,63,94,0.3)', tooltip: 'Could not reach Supabase (auth, RLS, or network) — showing demo data' },
       'mock-empty': { label: 'Live · empty', dotColor: '#f59e0b', textColor: '#f59e0b', bgColor: 'rgba(245,158,11,0.1)', borderColor: 'rgba(245,158,11,0.3)', tooltip: 'Connected to Supabase — no items yet' }
     };
-    const dataSourceChip = dataSourceChips[s.dataSource] || dataSourceChips.loading;
+    const chipKey = s.realtimeConnected && s.dataSource === 'live' ? 'live-realtime' : s.dataSource;
+    const dataSourceChip = dataSourceChips[chipKey] || dataSourceChips.loading;
 
     const base = {
       activeTabIsDashboard: s.activeTab === 'dashboard',
@@ -746,6 +823,10 @@ class Component extends DCLogic {
       availLabel: this.availLabel(selected.avail),
       trendPoints: this.trendPath(selected.trend),
       findingsView: selected.findings.map(f => ({ ...f, sevColor: this.severityColor(f.severity) })),
+      scanningPlaceholder: selected.status === 'running' && selected.scanners.length === 0,
+      scanStartedAtLabel: selected.scanStartedAt ? this.fmtTime(selected.scanStartedAt) : null,
+      scannersViewLabel: selected.status === 'running' && selected.scanners.length === 0
+        ? 'scanning…' : String(selected.scanners.length),
       scannersView: selected.scanners.map((sc, idx) => {
         const key = selected.id + ':' + idx;
         const expanded = !!s.expandedScanners[key];
@@ -758,6 +839,7 @@ class Component extends DCLogic {
           ...sc,
           expanded,
           chevron: expanded ? '▾' : '▸',
+          isRunning: sc.status === 'running',
           statusColor: scannerStatusColor(sc.status),
           statusLabel: scannerStatusLabel(sc.status),
           durationLabel: durationMs != null ? (durationMs / 1000).toFixed(1) + 's' : null,

--- a/prototypes/dc-dashboard/test/tripwire-live.test.js
+++ b/prototypes/dc-dashboard/test/tripwire-live.test.js
@@ -337,6 +337,10 @@ test('given partial-failed run with heatmap risk when loadData live then keeps r
   assert.equal(item.status, 'red', 'rollup heatmap_status must win over partial-failed');
   assert.equal(item.risk, 2.1);
   assert.match(item.errorMessage || '', /unreachable/i);
+  assert.equal(
+    item.errorMessage,
+    '1 out of 2 scanners unreachable — risk from completed engines',
+  );
   assert.notEqual(item.status, 'error');
   const tessl = item.scanners.find((s) => s.source === 'Tessl');
   assert.equal(tessl.status, 'unreachable');
@@ -509,6 +513,8 @@ test('given running run with stale green heatmap when loadData live then status 
   assert.equal(item.status, 'running', 'collapsed card must show SCANNING over stale heatmap');
   assert.equal(item.lastScan, null);
   assert.equal(item.scanStartedAt, '2026-08-01T15:00:00Z');
+  assert.equal(item.scanners.length, 0,
+    'no scan_run_scanners rows yet — dashboard must show placeholder');
   restoreFetch();
 });
 
@@ -729,6 +735,325 @@ test('given completed scanner without detail and no findings when loadData live 
     'Tessl scanner without detail must still get synthesized summary');
   restoreFetch();
 });
+
+test('given running scanner with console_output when loadData live then output.console_output relayed', async () => {
+  // -- Given --
+  const itemId = 'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1';
+  const runId = 'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2';
+  installWindow({
+    SUPABASE_URL: 'https://proj.supabase.co',
+    SUPABASE_ANON_KEY: 'anon',
+  });
+  mockFetchByTable({
+    items: [
+      {
+        id: itemId, type: 'skill', name: 'scanning-skill',
+        identifier: 'scanning-skill', heatmap_status: 'green',
+        risk_score: 0.1, quality_score: null,
+        install_locus: 'local', source_availability: 'source_on_disk',
+      },
+    ],
+    scan_runs: [
+      {
+        id: runId, item_id: itemId, status: 'running',
+        started_at: '2026-08-01T17:00:00Z', completed_at: null,
+      },
+    ],
+    scan_run_scanners: [
+      {
+        scan_run_id: runId,
+        scanner_source: 'Cisco Skill Scanner: static/bytecode/pipeline',
+        status: 'completed', checks_run: 5,
+        detail: '5 checks passed — no findings',
+        console_output: '{"findings": [], "findings_count": 5}\nScan completed successfully.',
+        started_at: '2026-08-01T17:00:01Z',
+        completed_at: '2026-08-01T17:00:15Z',
+      },
+      {
+        scan_run_id: runId,
+        scanner_source: 'Snyk',
+        status: 'running', checks_run: null,
+        detail: null,
+        console_output: null,
+        started_at: '2026-08-01T17:00:15Z',
+        completed_at: null,
+      },
+    ],
+    findings: [],
+  });
+  const loadData = await importLoadDataFresh();
+
+  // -- When --
+  const result = await loadData('live');
+  const item = result.data.items[0];
+
+  // -- Then --
+  assert.equal(item.status, 'running', 'item must show SCANNING while run is in flight');
+
+  const cisco = item.scanners.find(
+    (s) => s.source === 'Cisco Skill Scanner: static/bytecode/pipeline'
+  );
+  assert.equal(cisco.status, 'completed', 'completed scanner must keep completed status');
+  assert.equal(cisco.output.raw_summary, '5 checks passed — no findings',
+    'completed scanner detail relayed as raw_summary');
+  assert.equal(cisco.output.console_output,
+    '{"findings": [], "findings_count": 5}\nScan completed successfully.',
+    'console_output from Modal must be relayed into output.console_output');
+  assert.equal(cisco.output.duration_ms, 14000,
+    'duration_ms must be computed from started_at/completed_at');
+  assert.equal(cisco.started_at, '2026-08-01T17:00:01Z',
+    'started_at from scan_run_scanners must be surfaced');
+  assert.equal(cisco.completed_at, '2026-08-01T17:00:15Z',
+    'completed_at from scan_run_scanners must be surfaced');
+
+  const snyk = item.scanners.find((s) => s.source === 'Snyk');
+  assert.equal(snyk.status, 'running', 'in-flight scanner must stay running');
+  assert.equal(snyk.output.console_output, undefined,
+    'null console_output must not create output.console_output');
+  assert.equal(snyk.output.duration_ms, undefined,
+    'running scanner without completed_at must not have duration');
+  restoreFetch();
+});
+
+test('given completed scanner with console_output when loadData live then console text in output', async () => {
+  // -- Given --
+  const itemId = 'c3c3c3c3-c3c3-c3c3-c3c3-c3c3c3c3c3c3';
+  const runId = 'd4d4d4d4-d4d4-d4d4-d4d4-d4d4d4d4d4d4';
+  const consoleText = [
+    '=== Snyk Agent Scan ===',
+    'Scanning /tmp/scan-target...',
+    'Found 2 issues in 1 file',
+    'E004: Prompt injection in SKILL.md:12',
+    'W008: Hardcoded secret in config.py:3',
+  ].join('\n');
+  installWindow({
+    SUPABASE_URL: 'https://proj.supabase.co',
+    SUPABASE_ANON_KEY: 'anon',
+  });
+  mockFetchByTable({
+    items: [
+      {
+        id: itemId, type: 'skill', name: 'scanned-skill',
+        identifier: 'scanned-skill', heatmap_status: 'red',
+        risk_score: 2.0, quality_score: null,
+        install_locus: 'local', source_availability: 'source_on_disk',
+      },
+    ],
+    scan_runs: [
+      {
+        id: runId, item_id: itemId, status: 'complete',
+        started_at: '2026-08-01T16:00:00Z', completed_at: '2026-08-01T16:02:00Z',
+      },
+    ],
+    scan_run_scanners: [
+      {
+        scan_run_id: runId, scanner_source: 'Snyk',
+        status: 'completed', checks_run: 2,
+        detail: '2 checks — 2 findings (red): Prompt injection in SKILL.md:12',
+        console_output: consoleText,
+        started_at: '2026-08-01T16:01:00Z',
+        completed_at: '2026-08-01T16:01:45Z',
+      },
+    ],
+    findings: [
+      {
+        scan_run_id: runId, severity: 'red', category: 'prompt_injection',
+        file_path: 'SKILL.md', location: '12',
+        entity_kind: null, entity_name: null,
+        scanner_source: 'Snyk',
+        message: 'Prompt injection in SKILL.md:12',
+        snippet: null, cwe_ids: null,
+      },
+    ],
+  });
+  const loadData = await importLoadDataFresh();
+
+  // -- When --
+  const result = await loadData('live');
+  const scanner = result.data.items[0].scanners[0];
+
+  // -- Then --
+  assert.equal(scanner.output.console_output, consoleText,
+    'Modal console output must be passed through faithfully');
+  assert.match(scanner.output.raw_summary, /2 checks/,
+    'detail must still surface as raw_summary');
+  assert.equal(scanner.output.duration_ms, 45000,
+    'duration computed from scanner started_at to completed_at');
+  restoreFetch();
+});
+
+test('given running scanner with detail when loadData live then detail maps to raw_summary', async () => {
+  // -- Given --
+  const itemId = 'e5e5e5e5-e5e5-e5e5-e5e5-e5e5e5e5e5e5';
+  const runId = 'f6f6f6f6-f6f6-f6f6-f6f6-f6f6f6f6f6f6';
+  installWindow({
+    SUPABASE_URL: 'https://proj.supabase.co',
+    SUPABASE_ANON_KEY: 'anon',
+  });
+  mockFetchByTable({
+    items: [
+      {
+        id: itemId, type: 'mcp_server', name: 'mid-scan-server',
+        identifier: 'mid-scan-server', heatmap_status: 'grey',
+        risk_score: null, quality_score: null,
+        install_locus: 'cloud', source_availability: 'cloneable',
+      },
+    ],
+    scan_runs: [
+      {
+        id: runId, item_id: itemId, status: 'running',
+        started_at: '2026-08-01T17:30:00Z', completed_at: null,
+      },
+    ],
+    scan_run_scanners: [
+      {
+        scan_run_id: runId,
+        scanner_source: 'Cisco MCP Scanner: YARA',
+        status: 'running', checks_run: null,
+        detail: 'Starting Cisco MCP Scanner: YARA…',
+        console_output: null,
+        started_at: '2026-08-01T17:30:01Z',
+        completed_at: null,
+      },
+    ],
+    findings: [],
+  });
+  const loadData = await importLoadDataFresh();
+
+  // -- When --
+  const result = await loadData('live');
+  const scanner = result.data.items[0].scanners[0];
+
+  // -- Then --
+  assert.equal(scanner.status, 'running',
+    'running scanner status must be preserved');
+  assert.equal(scanner.output.raw_summary, 'Starting Cisco MCP Scanner: YARA…',
+    'running scanner detail must map to raw_summary (not reason)');
+  assert.equal(scanner.output.reason, undefined,
+    'running scanner detail must not map to reason');
+  restoreFetch();
+});
+
+test('given mock mode running item when loadData mock then scanners array has running entries', async () => {
+  // -- Given --
+  installWindow(undefined);
+  const loadData = await importLoadDataFresh();
+
+  // -- When --
+  const result = await loadData('mock');
+  const running = result.data.items.find((i) => i.status === 'running');
+
+  // -- Then --
+  assert.ok(running, 'mock data must include a running item');
+  assert.ok(running.scanners.length > 0,
+    'mock running item must have scanner rows so the drawer shows progress');
+  const completed = running.scanners.filter((s) => s.status === 'completed');
+  const stillRunning = running.scanners.filter((s) => s.status === 'running');
+  assert.ok(completed.length >= 1,
+    'mock running item must have at least one completed scanner');
+  assert.ok(stillRunning.length >= 1,
+    'mock running item must have at least one running scanner');
+  restoreFetch();
+});
+
+// ── Realtime integration tests ─────────────────────────────────────────────
+
+const REALTIME_MODULE = join(DASHBOARD_ROOT, 'tripwire-realtime.js');
+
+test('given tripwire-realtime module exists then it exports subscribe unsubscribe connected', async () => {
+  // -- Given --
+  assert.ok(existsSync(REALTIME_MODULE), 'tripwire-realtime.js must exist');
+
+  // -- When --
+  const source = readFileSync(REALTIME_MODULE, 'utf8');
+
+  // -- Then --
+  assert.match(source, /export\s+(async\s+)?function\s+subscribe/,
+    'must export a subscribe function');
+  assert.match(source, /export\s+function\s+unsubscribe/,
+    'must export an unsubscribe function');
+  assert.match(source, /export\s+function\s+connected/,
+    'must export a connected function');
+});
+
+test('given realtime module when no config then subscribe returns null', async () => {
+  // -- Given --
+  const url = `${pathToFileURL(REALTIME_MODULE).href}?t=${Date.now()}-${Math.random()}`;
+  const rt = await import(url);
+
+  // -- When --
+  const result = await rt.subscribe(null, () => {});
+
+  // -- Then --
+  assert.equal(result, null, 'subscribe must return null when config is missing');
+});
+
+test('given realtime module when empty anon key then subscribe returns null', async () => {
+  // -- Given --
+  const url = `${pathToFileURL(REALTIME_MODULE).href}?t=${Date.now()}-${Math.random()}`;
+  const rt = await import(url);
+
+  // -- When --
+  const result = await rt.subscribe(
+    { SUPABASE_URL: 'https://example.supabase.co', SUPABASE_ANON_KEY: '' },
+    () => {},
+  );
+
+  // -- Then --
+  assert.equal(result, null, 'subscribe must return null for empty anon key');
+});
+
+test('given dashboard html when inspecting chip labels then live-realtime chip exists', () => {
+  // -- Given --
+  const html = readFileSync(HTML_PATH, 'utf8');
+  const chipBlock = html.match(/const dataSourceChips = \{[\s\S]*?\n\s*\};/);
+  assert.ok(chipBlock, 'dataSourceChips block must exist');
+
+  // -- When --
+  const block = chipBlock[0];
+
+  // -- Then --
+  assert.match(block, /live-realtime/,
+    'chip map must have a live-realtime entry');
+  assert.match(block, /Live · Realtime/,
+    'realtime chip label must say Live · Realtime');
+});
+
+test('given dashboard html when inspecting state then realtimeConnected initialised false', () => {
+  // -- Given --
+  const html = readFileSync(HTML_PATH, 'utf8');
+
+  // -- When / Then --
+  assert.match(html, /realtimeConnected:\s*false/,
+    'state must initialise realtimeConnected to false');
+});
+
+test('given dashboard html when inspecting chip logic then realtimeConnected drives chip key', () => {
+  // -- Given --
+  const html = readFileSync(HTML_PATH, 'utf8');
+
+  // -- When / Then --
+  assert.match(html, /s\.realtimeConnected\s*&&\s*s\.dataSource\s*===\s*'live'/,
+    'chip key must check realtimeConnected && live source');
+  assert.match(html, /'live-realtime'/,
+    'chipKey expression must reference live-realtime');
+});
+
+test('given schema sql when inspecting realtime then publication adds required tables', () => {
+  // -- Given --
+  const schemaPath = join(DASHBOARD_ROOT, '..', '..', 'db', 'schema.sql');
+  const sql = readFileSync(schemaPath, 'utf8');
+
+  // -- When / Then --
+  assert.match(sql, /supabase_realtime\s+add\s+table\s+scan_runs/i,
+    'schema must add scan_runs to supabase_realtime publication');
+  assert.match(sql, /supabase_realtime\s+add\s+table\s+scan_run_scanners/i,
+    'schema must add scan_run_scanners to supabase_realtime publication');
+  assert.match(sql, /supabase_realtime\s+add\s+table\s+findings/i,
+    'schema must add findings to supabase_realtime publication');
+});
+
+// ── Smoke / live helpers ──────────────────────────────────────────────────
 
 function hasLiveConfigForSmoke() {
   if (!existsSync(CONFIG_PATH)) return false;

--- a/prototypes/dc-dashboard/test/tripwire-status.test.js
+++ b/prototypes/dc-dashboard/test/tripwire-status.test.js
@@ -115,3 +115,14 @@ test('given scanner unreachable when scannerExecMeta then uses error violet not 
   assert.equal(severityColor('red'), STATUS_META.red.color);
   assert.equal(severityColor('LOW'), STATUS_META.amber.color);
 });
+
+test('given scanner running when scannerExecMeta then uses scanning blue', () => {
+  // -- Given / When --
+  const meta = scannerExecMeta('running');
+
+  // -- Then --
+  assert.equal(meta.color, STATUS_META.running.color,
+    'running scanner must use SCANNING blue color');
+  assert.match(meta.label, /Running/i,
+    'running scanner label must say Running');
+});

--- a/prototypes/dc-dashboard/tripwire-data.js
+++ b/prototypes/dc-dashboard/tripwire-data.js
@@ -92,7 +92,13 @@ const items = [
 
   { id:'i11', type:'skill', name:'new-onboarding-helper', identifier:'new-onboarding-helper', status:'grey', risk:null, quality:null, locus:'unknown', avail:'unknown', lastScan:null, findings:[], scanners:[], trend:[] },
 
-  { id:'i13', type:'skill', name:'data-pipeline-runner', identifier:'data-pipeline-runner', status:'running', risk:null, quality:null, locus:'local', avail:'source_on_disk', lastScan:null, scanStartedAt:new Date(Date.now() - 45000).toISOString(), findings:[], scanners:[], trend:[],
+  { id:'i13', type:'skill', name:'data-pipeline-runner', identifier:'data-pipeline-runner', status:'running', risk:null, quality:null, locus:'local', avail:'source_on_disk', lastScan:null, scanStartedAt:new Date(Date.now() - 45000).toISOString(), findings:[], scanners:[
+    {source:'Cisco Skill Scanner: static/bytecode/pipeline', status:'completed', checks_run:28, output:{raw_summary:'28 checks passed — no findings', console_output:'{"findings": [], "findings_count": 28}\nScan completed.'}},
+    {source:'Cisco Skill Scanner: LLM-judge', status:'running', checks_run:null, output:{}},
+    {source:'Cisco Skill Scanner: AI Defense', status:'running', checks_run:null, output:{}},
+    {source:'Tessl', status:'running', checks_run:null, output:{}},
+    {source:'Snyk', status:'running', checks_run:null, output:{}}
+  ], trend:[],
   sandbox:{id:'sb_running1', started:new Date(Date.now() - 45000).toISOString(), completed:null, egressPhase:'static allowlist', denied:[], cleanup:false} },
 
   { id:'i12', type:'mcp_server', name:'mcp-scan-timeout-server', identifier:'mcp-scan-timeout-server', status:'error', risk:null, locus:'local', avail:'source_on_disk', lastScan:'2026-07-31T22:30:00Z', errorMessage:'Sandbox hard timeout after 300s — scan killed before completion.', findings:[], scanners:[

--- a/prototypes/dc-dashboard/tripwire-live.js
+++ b/prototypes/dc-dashboard/tripwire-live.js
@@ -87,9 +87,13 @@ async function fetchLiveData() {
       findings: mappedFindings,
     });
 
+    const unreachableCount = latestScanners.filter(
+      (s) => s.status === "unreachable"
+    ).length;
+    const totalScanners = latestScanners.length;
     const partialNote =
       runStatus === "partial-failed"
-        ? "Some scanners unreachable — risk from completed engines"
+        ? `${unreachableCount} out of ${totalScanners} scanners unreachable — risk from completed engines`
         : null;
 
     return {
@@ -116,7 +120,7 @@ async function fetchLiveData() {
         );
         const output = {};
         if (s.detail) {
-          if (s.status === "completed") {
+          if (s.status === "completed" || s.status === "running") {
             output.raw_summary = s.detail;
           } else {
             output.reason = s.detail;
@@ -137,6 +141,12 @@ async function fetchLiveData() {
             output.raw_summary = `${checks} checks — ${nFindings} finding${nFindings !== 1 ? "s" : ""} (${worst}): ${label}`;
           }
         }
+        if (s.console_output) {
+          output.console_output = s.console_output;
+        }
+        if (s.started_at && s.completed_at) {
+          output.duration_ms = new Date(s.completed_at) - new Date(s.started_at);
+        }
         if (
           s.scanner_source === "Tessl" &&
           item.quality_score != null
@@ -148,6 +158,8 @@ async function fetchLiveData() {
           status: s.status,
           checks_run: s.checks_run,
           detail: s.detail || null,
+          started_at: s.started_at || null,
+          completed_at: s.completed_at || null,
           output,
         };
       }),

--- a/prototypes/dc-dashboard/tripwire-realtime.js
+++ b/prototypes/dc-dashboard/tripwire-realtime.js
@@ -1,0 +1,96 @@
+/**
+ * Supabase Realtime subscription for the Tripwire dashboard.
+ *
+ * Subscribes to Postgres Changes on scan_runs, scan_run_scanners, and findings
+ * so the dashboard updates within ~1s of Modal writing a scanner result,
+ * instead of waiting for the 8s poll cycle.
+ *
+ * Prerequisites:
+ *   1. Tables added to supabase_realtime publication (see db/schema.sql).
+ *   2. RLS SELECT policies for anon on the subscribed tables (already present).
+ *
+ * Uses @supabase/supabase-js v2 loaded from ESM CDN at runtime — no npm
+ * install required for this HTML prototype.
+ */
+
+const CDN_URL = "https://esm.sh/@supabase/supabase-js@2";
+const DEBOUNCE_MS = 600;
+
+let _client = null;
+let _channel = null;
+let _debounceTimer = null;
+
+async function getCreateClient() {
+  const mod = await import(CDN_URL);
+  return mod.createClient;
+}
+
+/**
+ * Connect to Supabase Realtime and subscribe to scan-table changes.
+ *
+ * @param {{ SUPABASE_URL: string, SUPABASE_ANON_KEY: string }} config
+ * @param {(payload: object) => void} onUpdate  Debounced callback fired when
+ *   any scan_runs / scan_run_scanners / findings row changes.
+ * @returns {Promise<'SUBSCRIBED'|'CHANNEL_ERROR'|'TIMED_OUT'|null>}
+ *   Channel status string, or null if setup failed entirely.
+ */
+export async function subscribe(config, onUpdate) {
+  if (!config?.SUPABASE_URL || !config?.SUPABASE_ANON_KEY) return null;
+
+  let createClient;
+  try {
+    createClient = await getCreateClient();
+  } catch (err) {
+    console.warn("[tripwire-realtime] CDN load failed:", err.message);
+    return null;
+  }
+
+  _client = createClient(config.SUPABASE_URL, config.SUPABASE_ANON_KEY, {
+    realtime: { params: { eventsPerSecond: 10 } },
+  });
+
+  const debouncedCallback = (payload) => {
+    clearTimeout(_debounceTimer);
+    _debounceTimer = setTimeout(() => onUpdate(payload), DEBOUNCE_MS);
+  };
+
+  return new Promise((resolve) => {
+    _channel = _client
+      .channel("tripwire-scans")
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "scan_runs" },
+        debouncedCallback,
+      )
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "scan_run_scanners" },
+        debouncedCallback,
+      )
+      .on(
+        "postgres_changes",
+        { event: "INSERT", schema: "public", table: "findings" },
+        debouncedCallback,
+      )
+      .subscribe((status) => {
+        console.info("[tripwire-realtime]", status);
+        resolve(status);
+      });
+  });
+}
+
+/** Tear down the channel and client. Safe to call when not connected. */
+export function unsubscribe() {
+  clearTimeout(_debounceTimer);
+  if (_channel && _client) {
+    _client.removeChannel(_channel);
+    console.info("[tripwire-realtime] unsubscribed");
+  }
+  _channel = null;
+  _client = null;
+}
+
+/** @returns {boolean} true when a Realtime channel is active. */
+export function connected() {
+  return _channel != null;
+}

--- a/prototypes/dc-dashboard/tripwire-status.js
+++ b/prototypes/dc-dashboard/tripwire-status.js
@@ -126,6 +126,7 @@ export function severityColor(severity) {
  * Unreachable/failed use violet (error), not vuln-red.
  */
 export const SCANNER_EXEC_META = {
+  running: { color: STATUS_META.running.color, label: "◌ Running" },
   completed: { color: STATUS_META.green.color, label: "✓ Completed" },
   skipped_missing_credential: { color: STATUS_META.grey.color, label: "⊘ Skipped" },
   unreachable: { color: STATUS_META.error.color, label: "✗ Unreachable" },

--- a/sandbox/scan_app.py
+++ b/sandbox/scan_app.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import io
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -62,6 +63,74 @@ TIMEOUT_SECONDS = (
     300  # hard sandbox-level timeout (spec Phase 1): kill whole sandbox, mark scan_run failed
 )
 
+_PGRST_COLUMN_RE = re.compile(
+    r"PGRST204|could not find the .* column .* in the schema cache", re.IGNORECASE
+)
+
+_LEGACY_SCANNER_KEYS = frozenset({"scan_run_id", "scanner_source", "status", "checks_run"})
+
+
+def _is_column_error(exc: Exception) -> bool:
+    return bool(_PGRST_COLUMN_RE.search(str(exc)))
+
+
+def _to_runtime_error(exc: Exception, context: str) -> RuntimeError:
+    """Convert any Supabase/PostgREST exception to a plain RuntimeError.
+
+    Modal's local client may not have ``postgrest`` installed; deserializing a
+    ``postgrest.exceptions.APIError`` then fails with a confusing
+    ``ExecutionError``.  Plain ``RuntimeError`` always deserializes cleanly.
+    """
+    return RuntimeError(f"{context}: {exc}")
+
+
+def _safe_insert(supabase, table: str, row: dict, context: str) -> None:
+    """Insert *row* into *table*, falling back to legacy-safe columns on PGRST204.
+
+    If the first attempt fails because PostgREST can't find a column (the DB
+    hasn't had ``db/schema.sql`` migration applied), retry with only the
+    columns that existed in every schema version.  ``detail`` data is folded
+    into the ``detail`` field (truncated) so scan context survives the fallback.
+    """
+    try:
+        supabase.table(table).insert(row).execute()
+    except Exception as exc:
+        if not _is_column_error(exc):
+            raise _to_runtime_error(exc, context) from exc
+        print(
+            f"[tripwire] WARN column-missing ({exc}); retrying {table} "
+            f"insert with legacy columns — apply db/schema.sql to fix"
+        )
+        fallback = {k: v for k, v in row.items() if k in _LEGACY_SCANNER_KEYS}
+        console = row.get("console_output", "")
+        detail = row.get("detail", "")
+        merged = f"{detail}\n---\n{console}".strip(" \n-") if console else detail
+        if merged:
+            fallback["detail"] = merged[:4000]
+        try:
+            supabase.table(table).insert(fallback).execute()
+        except Exception as inner:
+            raise _to_runtime_error(
+                inner,
+                f"Supabase {table} insert failed even with legacy columns. "
+                "Apply db/schema.sql migration (tripwire setup --force)",
+            ) from inner
+
+
+def _safe_update(supabase, table: str, data: dict, eq_col: str, eq_val: str, context: str) -> None:
+    """Wrap a Supabase update, converting PostgREST errors to RuntimeError."""
+    try:
+        supabase.table(table).update(data).eq(eq_col, eq_val).execute()
+    except Exception as exc:
+        raise _to_runtime_error(exc, context) from exc
+
+
+def _safe_rpc(supabase, fn: str, params: dict, context: str) -> None:
+    try:
+        supabase.rpc(fn, params).execute()
+    except Exception as exc:
+        raise _to_runtime_error(exc, context) from exc
+
 
 @app.function(
     image=image,
@@ -84,42 +153,112 @@ def scan_item(
 
     supabase = create_client(os.environ["SUPABASE_URL"], os.environ["SUPABASE_SERVICE_ROLE_KEY"])
 
+    try:
+        _scan_item_inner(supabase, target, item_type, scan_run_id, item_id, target_archive)
+    except RuntimeError:
+        raise
+    except Exception as exc:
+        raise _to_runtime_error(exc, "scan_item unexpected error") from exc
+
+    # scratch disk teardown is implicit — the Modal sandbox itself is ephemeral and discarded here.
+
+
+def _scan_item_inner(
+    supabase,
+    target: str,
+    item_type: str,
+    scan_run_id: str,
+    item_id: str,
+    target_archive: bytes | None,
+) -> None:
+    def _mark_failed() -> None:
+        _safe_update(
+            supabase, "scan_runs",
+            {"status": "failed", "completed_at": datetime.now(UTC).isoformat()},
+            "id", scan_run_id, "mark scan_run failed",
+        )
+        _safe_rpc(supabase, "tripwire_rollup_item", {"p_item_id": item_id}, "rollup after failure")
+
     workdir = "/tmp/scan-target"
     try:
         _acquire_target(target, item_type, workdir, target_archive=target_archive)
-        results = run_all_scanners(workdir=workdir, item_type=item_type, target=target)
-    except (
-        Exception
-    ):  # acquisition or scanner-runner crash — whole run fails, never silently "complete"
-        supabase.table("scan_runs").update(
-            {"status": "failed", "completed_at": datetime.now(UTC).isoformat()}
-        ).eq("id", scan_run_id).execute()
-        supabase.rpc("tripwire_rollup_item", {"p_item_id": item_id}).execute()
+    except Exception:
+        _mark_failed()
         raise
 
-    for finding in results["findings"]:
-        supabase.table("findings").insert(
-            {**finding, "scan_run_id": scan_run_id, "item_id": item_id}
-        ).execute()
-    for scanner_row in results["scanner_rows"]:
-        supabase.table("scan_run_scanners").insert(
-            {**scanner_row, "scan_run_id": scan_run_id}
-        ).execute()
-    if results["quality_score"] is not None:
-        supabase.table("items").update({"quality_score": results["quality_score"]}).eq(
-            "id", item_id
-        ).execute()
+    def _on_scanner_start(sources):
+        """Insert running placeholder rows so the dashboard shows progress."""
+        now = datetime.now(UTC).isoformat()
+        for source in sources:
+            try:
+                supabase.table("scan_run_scanners").insert(
+                    {
+                        "scan_run_id": scan_run_id,
+                        "scanner_source": source,
+                        "status": "running",
+                        "started_at": now,
+                    }
+                ).execute()
+            except Exception as exc:
+                print(f"[scan] warning: could not insert running row for {source}: {exc}")
 
-    supabase.table("scan_runs").update(
-        {
-            "status": results["overall_status"],
-            "completed_at": datetime.now(UTC).isoformat(),
-        }
-    ).eq("id", scan_run_id).execute()
+    def _on_scanner_done(findings, scanner_rows, quality_score=None):
+        """Write results — update existing running row or insert fresh."""
+        now = datetime.now(UTC).isoformat()
+        for row in scanner_rows:
+            payload = {**row, "scan_run_id": scan_run_id, "completed_at": now}
+            try:
+                resp = (
+                    supabase.table("scan_run_scanners")
+                    .update(payload)
+                    .eq("scan_run_id", scan_run_id)
+                    .eq("scanner_source", row["scanner_source"])
+                    .execute()
+                )
+                if not resp.data:
+                    _safe_insert(
+                        supabase, "scan_run_scanners", payload,
+                        "scan_run_scanners insert",
+                    )
+            except Exception:
+                try:
+                    _safe_insert(
+                        supabase, "scan_run_scanners", payload,
+                        "scan_run_scanners insert (update-fallback)",
+                    )
+                except Exception as exc:
+                    print(f"[scan] warning: scanner row write failed for {row.get('scanner_source')}: {exc}")
+        for finding in findings:
+            _safe_insert(
+                supabase, "findings",
+                {**finding, "scan_run_id": scan_run_id, "item_id": item_id},
+                "findings insert",
+            )
+        if quality_score is not None:
+            _safe_update(
+                supabase, "items",
+                {"quality_score": quality_score},
+                "id", item_id, "update quality_score",
+            )
 
-    supabase.rpc("tripwire_rollup_item", {"p_item_id": item_id}).execute()
+    try:
+        results = run_all_scanners(
+            workdir=workdir,
+            item_type=item_type,
+            target=target,
+            on_scanner_done=_on_scanner_done,
+            on_scanner_start=_on_scanner_start,
+        )
+    except Exception:
+        _mark_failed()
+        raise
 
-    # scratch disk teardown is implicit — the Modal sandbox itself is ephemeral and discarded here.
+    _safe_update(
+        supabase, "scan_runs",
+        {"status": results["overall_status"], "completed_at": datetime.now(UTC).isoformat()},
+        "id", scan_run_id, "mark scan_run completed",
+    )
+    _safe_rpc(supabase, "tripwire_rollup_item", {"p_item_id": item_id}, "rollup after scan")
 
 
 @app.local_entrypoint()

--- a/sandbox/scan_app.py
+++ b/sandbox/scan_app.py
@@ -173,9 +173,12 @@ def _scan_item_inner(
 ) -> None:
     def _mark_failed() -> None:
         _safe_update(
-            supabase, "scan_runs",
+            supabase,
+            "scan_runs",
             {"status": "failed", "completed_at": datetime.now(UTC).isoformat()},
-            "id", scan_run_id, "mark scan_run failed",
+            "id",
+            scan_run_id,
+            "mark scan_run failed",
         )
         _safe_rpc(supabase, "tripwire_rollup_item", {"p_item_id": item_id}, "rollup after failure")
 
@@ -217,28 +220,38 @@ def _scan_item_inner(
                 )
                 if not resp.data:
                     _safe_insert(
-                        supabase, "scan_run_scanners", payload,
+                        supabase,
+                        "scan_run_scanners",
+                        payload,
                         "scan_run_scanners insert",
                     )
             except Exception:
                 try:
                     _safe_insert(
-                        supabase, "scan_run_scanners", payload,
+                        supabase,
+                        "scan_run_scanners",
+                        payload,
                         "scan_run_scanners insert (update-fallback)",
                     )
                 except Exception as exc:
-                    print(f"[scan] warning: scanner row write failed for {row.get('scanner_source')}: {exc}")
+                    print(
+                        f"[scan] warning: scanner row write failed for {row.get('scanner_source')}: {exc}"
+                    )
         for finding in findings:
             _safe_insert(
-                supabase, "findings",
+                supabase,
+                "findings",
                 {**finding, "scan_run_id": scan_run_id, "item_id": item_id},
                 "findings insert",
             )
         if quality_score is not None:
             _safe_update(
-                supabase, "items",
+                supabase,
+                "items",
                 {"quality_score": quality_score},
-                "id", item_id, "update quality_score",
+                "id",
+                item_id,
+                "update quality_score",
             )
 
     try:
@@ -254,9 +267,12 @@ def _scan_item_inner(
         raise
 
     _safe_update(
-        supabase, "scan_runs",
+        supabase,
+        "scan_runs",
         {"status": results["overall_status"], "completed_at": datetime.now(UTC).isoformat()},
-        "id", scan_run_id, "mark scan_run completed",
+        "id",
+        scan_run_id,
+        "mark scan_run completed",
     )
     _safe_rpc(supabase, "tripwire_rollup_item", {"p_item_id": item_id}, "rollup after scan")
 

--- a/sandbox/scanners.py
+++ b/sandbox/scanners.py
@@ -17,6 +17,7 @@ import shutil
 import subprocess
 
 SCAN_TIMEOUT = 240  # leaves headroom under the sandbox's 300s hard timeout
+MAX_CONSOLE_CHARS = 3000  # per-scanner console capture limit for Supabase detail
 
 # Severity collapse (docs/research/adapters/scanner-output-adapters.md §1, PROPOSED)
 _SNYK_CODE_CATEGORY = {
@@ -46,12 +47,14 @@ def _skipped(source, reason="skipped_missing_credential"):
     return {"scanner_source": source, "status": reason, "checks_run": 0}
 
 
-def _unreachable(source, stderr):
+def _unreachable(source, stderr, console_output=None):
     detail = (stderr or "").strip()
     print(f"[{source}] unreachable: {detail[:400]}")
     row = {"scanner_source": source, "status": "unreachable", "checks_run": 0}
     if detail:
         row["detail"] = detail[:4000]
+    if console_output:
+        row["console_output"] = console_output
     return row
 
 
@@ -73,12 +76,32 @@ def _safe_json(text):
     return None
 
 
+def _truncate_console(text, max_chars=MAX_CONSOLE_CHARS):
+    """Truncate raw console text, preserving head and tail for context."""
+    if not text or len(text) <= max_chars:
+        return text or None
+    half = max_chars // 2 - 30
+    omitted = len(text) - 2 * half
+    return f"{text[:half]}\n…[{omitted} chars omitted]…\n{text[-half:]}"
+
+
+def _build_console(stdout, stderr):
+    """Build a truncated console capture from scanner subprocess output."""
+    parts = []
+    if stdout and stdout.strip():
+        parts.append(stdout.strip())
+    if stderr and stderr.strip():
+        prefix = "--- stderr ---\n" if parts else ""
+        parts.append(f"{prefix}{stderr.strip()}")
+    return _truncate_console("\n".join(parts)) if parts else None
+
+
 # ---- Cisco Skill Scanner ----------------------------------------------------
 # docs/research/adapters/scanner-output-adapters.md §3
 # Capture: skill-scanner scan <path> --format json  (avoid --output: flaky on a tested build)
 
 
-def _completed(source, checks_run, findings_for_scanner):
+def _completed(source, checks_run, findings_for_scanner, console_output=None):
     """Build a completed scanner row with a human-readable detail summary."""
     n_findings = len(findings_for_scanner)
     if n_findings == 0:
@@ -92,12 +115,15 @@ def _completed(source, checks_run, findings_for_scanner):
         if len(brief) > 80:
             brief = brief[:77] + "…"
         detail = f"{checks_run} checks — {n_findings} finding{'s' if n_findings != 1 else ''} ({worst}): {brief}"
-    return {
+    row = {
         "scanner_source": source,
         "status": "completed",
         "checks_run": checks_run,
         "detail": detail,
     }
+    if console_output:
+        row["console_output"] = console_output
+    return row
 
 
 def run_cisco_skill_scanner(workdir):
@@ -109,12 +135,13 @@ def run_cisco_skill_scanner(workdir):
 
     def _invoke(extra_flags, source):
         code, out, err = _run(["skill-scanner", "scan", workdir, "--format", "json", *extra_flags])
+        console = _build_console(out, err)
         if code != 0:
-            return [_unreachable(source, err)], []
+            return [_unreachable(source, err, console_output=console)], []
         parsed = _safe_json(out) or {}
         mapped = _map_skill_findings(parsed, source)
         checks = parsed.get("findings_count", len(parsed.get("findings", [])) or 1)
-        return [_completed(source, checks, mapped)], mapped
+        return [_completed(source, checks, mapped, console_output=console)], mapped
 
     r, f = _invoke([], source_static)
     rows += r
@@ -316,11 +343,20 @@ def run_cisco_mcp_scanner(workdir, target):
             rows.append(_unreachable(_MCP_ANALYZER_LABEL[_normalize_analyzer_key(name)], detail))
     else:
         code, out, err = _run(build_mcp_live_cmd(live, mode_args))
+        console = _build_console(out, err)
         if code != 0:
             for name in live:
-                rows.append(_unreachable(_MCP_ANALYZER_LABEL[_normalize_analyzer_key(name)], err))
+                rows.append(
+                    _unreachable(
+                        _MCP_ANALYZER_LABEL[_normalize_analyzer_key(name)],
+                        err,
+                        console_output=console,
+                    )
+                )
         else:
             f, r, _requested = _map_mcp_envelope(_safe_json(out) or {}, live)
+            for row in r:
+                row["console_output"] = console
             findings += f
             rows += r
 
@@ -337,18 +373,19 @@ def run_cisco_mcp_scanner(workdir, target):
         rows.append(_skipped(beh_label))
     else:
         code, out, err = _run(build_mcp_behavioral_cmd(workdir))
+        beh_console = _build_console(out, err)
         if code != 0:
-            rows.append(_unreachable(beh_label, err))
+            rows.append(_unreachable(beh_label, err, console_output=beh_console))
         else:
             envelope = _safe_json(out) or {}
-            # Force behavioral into requested_analyzers so the row maps correctly
-            # even when the subcommand omits that envelope field.
             if not envelope.get("requested_analyzers"):
                 envelope = {**envelope, "requested_analyzers": ["behavioral"]}
             f, r, _ = _map_mcp_envelope(envelope, ["behavioral"])
             findings += f
             beh_rows = [row for row in r if row["scanner_source"] == beh_label]
-            rows += beh_rows or [_completed(beh_label, 1, [])]
+            for row in beh_rows:
+                row["console_output"] = beh_console
+            rows += beh_rows or [_completed(beh_label, 1, [], console_output=beh_console)]
 
     return findings, rows
 
@@ -359,12 +396,11 @@ def run_cisco_mcp_scanner(workdir, target):
 
 
 def _snyk_cmd(workdir, item_type):
-    # Skills require --skills (boolean or path). Without it, snyk-agent-scan
-    # treats the path as MCP config and exits nonzero with empty stderr.
+    # --ci always requires --dangerously-run-mcp-servers (Snyk Agent Scan policy).
+    # Skills additionally need --skills so the path is treated as SKILL.md, not MCP config.
+    flags = ["--ci", "--dangerously-run-mcp-servers", "--json", workdir]
     if item_type == "skill":
-        flags = ["--ci", "--skills", "--json", workdir]
-    else:
-        flags = ["--ci", "--dangerously-run-mcp-servers", "--json", workdir]
+        flags = ["--ci", "--dangerously-run-mcp-servers", "--skills", "--json", workdir]
     if _which("snyk-agent-scan"):
         return ["snyk-agent-scan", *flags]
     if _which("uvx"):
@@ -383,23 +419,26 @@ def run_snyk(workdir, item_type="mcp_server"):
         ]
 
     code, out, err = _run(cmd)
-    if code != 0:
-        return [], [_unreachable(source, err or out or f"exit {code}")]
+    console = _build_console(out, err)
+    root = _safe_json(out) or _safe_json(err) or {}
+    if not isinstance(root, dict) or not root:
+        return [], [_unreachable(source, err or out or f"exit {code}", console_output=console)]
 
-    root = _safe_json(out) or {}
     findings, checks = [], 0
-    for abs_path, path_result in root.items():
+    path_errors = []
+    for _abs_path, path_result in root.items():
         if not isinstance(path_result, dict):
             continue
         if path_result.get("error"):
-            continue  # path-level failure — does not fabricate a finding
+            path_errors.append(str(path_result.get("error")))
+            continue
         for issue in path_result.get("issues", []) or []:
             checks += 1
             code_ = issue.get("code", "")
             severity = (
                 "red" if code_.startswith("E") else ("amber" if code_.startswith("W") else None)
             )
-            if severity is None:  # X* runtime/engine codes are not security findings
+            if severity is None:
                 continue
             findings.append(
                 {
@@ -409,7 +448,16 @@ def run_snyk(workdir, item_type="mcp_server"):
                     "scanner_source": source,
                 }
             )
-    return findings, [_completed(source, checks or 1, findings)]
+
+    if findings or checks or not path_errors:
+        return findings, [_completed(source, checks or 1, findings, console_output=console)]
+    return [], [
+        _unreachable(
+            source,
+            "; ".join(path_errors) or err or out or f"exit {code}",
+            console_output=console,
+        )
+    ]
 
 
 # ---- Tessl (skills quality axis only, never findings) -----------------------
@@ -439,17 +487,17 @@ def run_tessl(workdir):
         return None, [_skipped("Tessl")]
     if not _which("npx"):
         return None, [_unreachable("Tessl", "npx not available (node/npm missing from image)")]
-    # Current Tessl CLI (0.93+): `tessl skill review --json <path>`
-    # Legacy `review run … --workspace` fails with upload URL 403 on headless tokens.
     code, out, err = _run(["npx", "--yes", "tessl@latest", "skill", "review", "--json", workdir])
+    console = _build_console(out, err)
     if code != 0:
-        return None, [_unreachable("Tessl", err or out)]
+        return None, [_unreachable("Tessl", err or out, console_output=console)]
     parsed = _safe_json(out) or {}
     score = _tessl_quality_score(parsed)
     detail = f"quality_score = {score}" if score is not None else "1 check completed"
-    return score, [
-        {"scanner_source": "Tessl", "status": "completed", "checks_run": 1, "detail": detail}
-    ]
+    row = {"scanner_source": "Tessl", "status": "completed", "checks_run": 1, "detail": detail}
+    if console:
+        row["console_output"] = console
+    return score, [row]
 
 
 def _collapse_severity(raw):
@@ -467,24 +515,66 @@ def _collapse_severity(raw):
     return None  # SAFE / empty — no finding row
 
 
-def run_all_scanners(workdir, item_type, target):
+SKILL_SCANNER_SOURCES = [
+    "Cisco Skill Scanner: static/bytecode/pipeline",
+    "Cisco Skill Scanner: LLM-judge",
+    "Cisco Skill Scanner: AI Defense",
+]
+
+MCP_SCANNER_SOURCES = list(_MCP_ANALYZER_LABEL.values())
+
+TESSL_SOURCES = ["Tessl"]
+SNYK_SOURCES = ["Snyk"]
+
+
+def run_all_scanners(workdir, item_type, target, on_scanner_done=None, on_scanner_start=None):
+    """Run all applicable scanners, optionally relaying results incrementally.
+
+    When *on_scanner_start* is provided it is called before each scanner group
+    with the list of scanner_source names about to run.  This lets the caller
+    insert ``status='running'`` placeholder rows so the dashboard has something
+    to display immediately (within one poll cycle).
+
+    When *on_scanner_done* is provided it is called after each scanner group
+    finishes with ``(findings, scanner_rows, quality_score)``.  This lets the
+    caller (scan_app) persist rows/findings to Supabase as they arrive so the
+    dashboard shows progress scanner-by-scanner.
+    """
     findings, scanner_rows = [], []
     quality_score = None
 
+    def _relay(f, r, qs=None):
+        if on_scanner_done:
+            on_scanner_done(f, r, qs)
+
+    def _signal_start(sources):
+        if on_scanner_start:
+            on_scanner_start(sources)
+
     if item_type == "skill":
+        _signal_start(SKILL_SCANNER_SOURCES)
         f, r = run_cisco_skill_scanner(workdir)
         findings += f
         scanner_rows += r
-        quality_score, r = run_tessl(workdir)
+        _relay(f, r)
+        _signal_start(TESSL_SOURCES)
+        qs, r = run_tessl(workdir)
+        if qs is not None:
+            quality_score = qs
         scanner_rows += r
+        _relay([], r, qs)
     else:
+        _signal_start(MCP_SCANNER_SOURCES)
         f, r = run_cisco_mcp_scanner(workdir, target)
         findings += f
         scanner_rows += r
+        _relay(f, r)
 
+    _signal_start(SNYK_SOURCES)
     f, r = run_snyk(workdir, item_type)
     findings += f
     scanner_rows += r
+    _relay(f, r)
 
     any_unreachable = any(row["status"] == "unreachable" for row in scanner_rows)
     overall_status = "partial-failed" if any_unreachable else "complete"

--- a/sandbox/test_scan_app.py
+++ b/sandbox/test_scan_app.py
@@ -9,12 +9,10 @@ Scope: _is_column_error detection; _safe_insert fallback on PGRST204;
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock
 
 import pytest
-
 import scan_app
-
 
 # ---------------------------------------------------------------------------
 # _is_column_error
@@ -212,7 +210,8 @@ def test_given_non_column_error_when_safe_insert_then_raises_runtime_error() -> 
     ### When / Then
     with pytest.raises(RuntimeError, match="JWT expired"):
         scan_app._safe_insert(
-            mock_sb, "scan_run_scanners",
+            mock_sb,
+            "scan_run_scanners",
             {"scan_run_id": "x", "scanner_source": "y", "status": "completed", "checks_run": 0},
             "test",
         )
@@ -240,7 +239,9 @@ def test_given_supabase_error_when_safe_update_then_raises_runtime_error() -> No
 
     ### When / Then
     with pytest.raises(RuntimeError, match="mark scan_run failed"):
-        scan_app._safe_update(mock_sb, "scan_runs", {"status": "failed"}, "id", "run-1", "mark scan_run failed")
+        scan_app._safe_update(
+            mock_sb, "scan_runs", {"status": "failed"}, "id", "run-1", "mark scan_run failed"
+        )
 
 
 def test_given_supabase_error_when_safe_rpc_then_raises_runtime_error() -> None:

--- a/sandbox/test_scan_app.py
+++ b/sandbox/test_scan_app.py
@@ -1,0 +1,261 @@
+"""
+Tests for sandbox.scan_app Supabase resilience helpers.
+
+Author: swami
+Created: 2026-08-01
+Scope: _is_column_error detection; _safe_insert fallback on PGRST204;
+       _to_runtime_error Modal exception hygiene; _safe_update / _safe_rpc wrapping
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+import scan_app
+
+
+# ---------------------------------------------------------------------------
+# _is_column_error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Could not find the 'completed_at' column of 'scan_run_scanners' in the schema cache (PGRST204)",
+        "PGRST204: Could not find the 'started_at' column",
+        "pgrst204 something something",
+        "Could not find the 'console_output' column of 'scan_run_scanners' in the schema cache",
+    ],
+    ids=["full_pgrst204", "code_prefix", "case_insensitive", "no_code_but_column_text"],
+)
+def test_given_column_missing_message_when_checked_then_detected(message: str) -> None:
+    """
+    Scenario: Column-missing PostgREST errors are recognised for fallback.
+    Slice: _is_column_error — PGRST204 detection
+
+    Given an exception whose string matches a PGRST204 column-missing pattern,
+    When _is_column_error is called,
+    Then it returns True.
+    """
+    ### Given / When / Then
+    assert scan_app._is_column_error(Exception(message)) is True
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "JWT expired",
+        "connection refused",
+        "PGRST205: table not found",
+        "",
+    ],
+    ids=["jwt", "conn_refused", "table_not_found", "empty"],
+)
+def test_given_non_column_error_when_checked_then_not_detected(message: str) -> None:
+    """
+    Scenario: Non-column errors are not mistakenly matched.
+    Slice: _is_column_error — false positives
+
+    Given an exception unrelated to missing columns,
+    When _is_column_error is called,
+    Then it returns False.
+    """
+    ### Given / When / Then
+    assert scan_app._is_column_error(Exception(message)) is False
+
+
+# ---------------------------------------------------------------------------
+# _to_runtime_error
+# ---------------------------------------------------------------------------
+
+
+def test_given_postgrest_exception_when_converted_then_runtime_error() -> None:
+    """
+    Scenario: PostgREST exceptions become plain RuntimeError for Modal.
+    Slice: _to_runtime_error — Modal deserialization hygiene
+
+    Given an exception with a class Modal can't deserialize,
+    When _to_runtime_error wraps it,
+    Then the result is a RuntimeError with the original message preserved.
+    """
+    ### Given
+    original = ValueError("Could not find the 'completed_at' column (PGRST204)")
+
+    ### When
+    wrapped = scan_app._to_runtime_error(original, "scan_run_scanners insert")
+
+    ### Then
+    assert isinstance(wrapped, RuntimeError)
+    assert "PGRST204" in str(wrapped)
+    assert "scan_run_scanners insert" in str(wrapped)
+
+
+# ---------------------------------------------------------------------------
+# _safe_insert — fallback behaviour
+# ---------------------------------------------------------------------------
+
+
+def _mock_supabase_column_error():
+    """Build a Supabase mock whose first insert raises a PGRST204 column error."""
+    mock_sb = MagicMock()
+    error = Exception(
+        "Could not find the 'completed_at' column of 'scan_run_scanners' "
+        "in the schema cache (PGRST204)"
+    )
+    inserted_rows = []
+
+    def _insert_side_effect(row):
+        inserted_rows.append(row)
+        chain = MagicMock()
+        if len(inserted_rows) == 1:
+            chain.execute.side_effect = error
+        return chain
+
+    mock_sb.table.return_value.insert = _insert_side_effect
+    return mock_sb, inserted_rows
+
+
+def test_given_pgrst204_when_safe_insert_then_retries_with_legacy_cols() -> None:
+    """
+    Scenario: PGRST204 on insert triggers a fallback to legacy-safe columns.
+    Slice: _safe_insert — column-missing fallback
+
+    Given a Supabase mock that raises PGRST204 on the first insert,
+    When _safe_insert is called with a row containing new columns,
+    Then it retries with only legacy columns and does not raise.
+    """
+    ### Given
+    mock_sb, inserted_rows = _mock_supabase_column_error()
+    row = {
+        "scan_run_id": "run-1",
+        "scanner_source": "Snyk",
+        "status": "completed",
+        "checks_run": 3,
+        "detail": "3 checks passed",
+        "console_output": "raw output here",
+        "completed_at": "2026-08-01T12:00:00Z",
+    }
+
+    ### When
+    scan_app._safe_insert(mock_sb, "scan_run_scanners", row, "test insert")
+
+    ### Then — two insert calls: original (failed) + fallback (succeeded)
+    assert len(inserted_rows) == 2, "expected original + fallback insert attempts"  # noqa: PLR2004
+    fallback = inserted_rows[1]
+    assert "completed_at" not in fallback, "fallback must strip new columns"
+    assert "console_output" not in fallback, "fallback must strip new columns"
+    assert fallback["scanner_source"] == "Snyk"
+    assert fallback["scan_run_id"] == "run-1"
+
+
+def test_given_pgrst204_when_safe_insert_then_fallback_has_merged_detail() -> None:
+    """
+    Scenario: Fallback insert merges console_output into detail field.
+    Slice: _safe_insert — detail preservation
+
+    Given a PGRST204 failure with console_output in the row,
+    When fallback insert is built,
+    Then console data is merged into detail (truncated to 4000 chars).
+    """
+    ### Given
+    mock_sb = MagicMock()
+    error = Exception("PGRST204 column missing")
+    inserted_rows = []
+
+    def _insert(row):
+        chain = MagicMock()
+        if len(inserted_rows) == 0:
+            chain.execute.side_effect = error
+        else:
+            chain.execute.return_value = None
+        inserted_rows.append(row)
+        return chain
+
+    mock_sb.table.return_value.insert = _insert
+    row = {
+        "scan_run_id": "run-1",
+        "scanner_source": "Snyk",
+        "status": "completed",
+        "checks_run": 1,
+        "detail": "1 check",
+        "console_output": "A" * 5000,
+        "completed_at": "2026-08-01T12:00:00Z",
+    }
+
+    ### When
+    scan_app._safe_insert(mock_sb, "scan_run_scanners", row, "test insert")
+
+    ### Then
+    fallback = inserted_rows[1]
+    assert "completed_at" not in fallback
+    assert "console_output" not in fallback
+    assert "1 check" in fallback["detail"]
+    assert len(fallback["detail"]) <= 4000  # noqa: PLR2004
+
+
+def test_given_non_column_error_when_safe_insert_then_raises_runtime_error() -> None:
+    """
+    Scenario: Non-column Supabase errors raise RuntimeError without fallback.
+    Slice: _safe_insert — non-recoverable path
+
+    Given a Supabase mock that raises a non-column error (e.g. auth),
+    When _safe_insert is called,
+    Then RuntimeError is raised immediately without a fallback retry.
+    """
+    ### Given
+    mock_sb = MagicMock()
+    mock_sb.table.return_value.insert.return_value.execute.side_effect = Exception("JWT expired")
+
+    ### When / Then
+    with pytest.raises(RuntimeError, match="JWT expired"):
+        scan_app._safe_insert(
+            mock_sb, "scan_run_scanners",
+            {"scan_run_id": "x", "scanner_source": "y", "status": "completed", "checks_run": 0},
+            "test",
+        )
+
+
+# ---------------------------------------------------------------------------
+# _safe_update / _safe_rpc
+# ---------------------------------------------------------------------------
+
+
+def test_given_supabase_error_when_safe_update_then_raises_runtime_error() -> None:
+    """
+    Scenario: _safe_update converts PostgREST errors to RuntimeError.
+    Slice: _safe_update — exception hygiene
+
+    Given a Supabase mock that raises on update,
+    When _safe_update is called,
+    Then RuntimeError is raised with context.
+    """
+    ### Given
+    mock_sb = MagicMock()
+    mock_sb.table.return_value.update.return_value.eq.return_value.execute.side_effect = Exception(
+        "PGRST204"
+    )
+
+    ### When / Then
+    with pytest.raises(RuntimeError, match="mark scan_run failed"):
+        scan_app._safe_update(mock_sb, "scan_runs", {"status": "failed"}, "id", "run-1", "mark scan_run failed")
+
+
+def test_given_supabase_error_when_safe_rpc_then_raises_runtime_error() -> None:
+    """
+    Scenario: _safe_rpc converts PostgREST errors to RuntimeError.
+    Slice: _safe_rpc — exception hygiene
+
+    Given a Supabase mock that raises on rpc,
+    When _safe_rpc is called,
+    Then RuntimeError is raised with context.
+    """
+    ### Given
+    mock_sb = MagicMock()
+    mock_sb.rpc.return_value.execute.side_effect = Exception("connection refused")
+
+    ### When / Then
+    with pytest.raises(RuntimeError, match="rollup"):
+        scan_app._safe_rpc(mock_sb, "tripwire_rollup_item", {"p_item_id": "item-1"}, "rollup")

--- a/sandbox/test_scanners_status.py
+++ b/sandbox/test_scanners_status.py
@@ -199,9 +199,7 @@ def test_given_callback_when_run_all_then_callback_called_per_scanner_group() ->
     callback_calls = []
 
     def on_done(findings, rows, quality_score=None):
-        callback_calls.append(
-            {"findings": findings, "rows": rows, "quality_score": quality_score}
-        )
+        callback_calls.append({"findings": findings, "rows": rows, "quality_score": quality_score})
 
     ### When
     with (
@@ -248,7 +246,8 @@ def test_given_no_callback_when_run_all_then_works_unchanged() -> None:
             return_value=([], [{"scanner_source": "YARA", "status": "completed", "checks_run": 1}]),
         ),
         patch.object(
-            scanners, "run_snyk",
+            scanners,
+            "run_snyk",
             return_value=([], [{"scanner_source": "Snyk", "status": "completed", "checks_run": 1}]),
         ),
     ):

--- a/sandbox/test_scanners_status.py
+++ b/sandbox/test_scanners_status.py
@@ -1,9 +1,12 @@
 """
-Tests for sandbox.scanners overall status and unreachable detail rows.
+Tests for sandbox.scanners overall status, unreachable detail, console capture,
+and incremental callback relay.
 
 Author: swami
 Created: 2026-08-01
-Scope: run_all_scanners overall_status; _unreachable detail truncation
+Scope: run_all_scanners overall_status; _unreachable detail truncation;
+       _build_console / _truncate_console; on_scanner_done callback relay;
+       _completed console_output passthrough
 """
 
 from __future__ import annotations
@@ -32,6 +35,228 @@ def test_given_unreachable_stderr_when_building_row_then_detail_is_capped() -> N
     assert row["status"] == "unreachable"
     assert row["checks_run"] == 0
     assert row["detail"] == "x" * 4000
+
+
+def test_given_unreachable_with_console_when_building_row_then_console_output_present() -> None:
+    """
+    Scenario: Unreachable scanner rows also carry raw console output.
+    Slice: _unreachable — console_output relay
+
+    Given a stderr and console_output,
+    When _unreachable builds the row,
+    Then console_output is included in the row.
+    """
+    ### Given / When
+    row = scanners._unreachable("Snyk", "exit 1", console_output="full raw output here")
+
+    ### Then
+    assert row["console_output"] == "full raw output here"
+
+
+def test_given_stdout_and_stderr_when_build_console_then_combined_output() -> None:
+    """
+    Scenario: _build_console combines stdout and stderr with a separator.
+    Slice: _build_console — concatenation
+
+    Given stdout with JSON and stderr with warnings,
+    When _build_console is called,
+    Then output contains both sections with stderr separator.
+    """
+    ### Given
+    stdout = '{"findings": []}'
+    stderr = "npm warn deprecated"
+
+    ### When
+    result = scanners._build_console(stdout, stderr)
+
+    ### Then
+    assert '{"findings": []}' in result
+    assert "--- stderr ---" in result
+    assert "npm warn deprecated" in result
+
+
+def test_given_only_stdout_when_build_console_then_no_stderr_label() -> None:
+    """
+    Scenario: _build_console with only stdout omits stderr separator.
+    Slice: _build_console — stdout-only
+
+    Given stdout text and empty stderr,
+    When _build_console is called,
+    Then result contains stdout without any stderr label.
+    """
+    ### Given / When
+    result = scanners._build_console("scan complete", "")
+
+    ### Then
+    assert result == "scan complete"
+    assert "stderr" not in result
+
+
+def test_given_empty_output_when_build_console_then_none() -> None:
+    """
+    Scenario: _build_console with empty/whitespace returns None.
+    Slice: _build_console — empty input
+
+    Given empty stdout and stderr,
+    When _build_console is called,
+    Then result is None.
+    """
+    ### Given / When / Then
+    assert scanners._build_console("", "") is None
+    assert scanners._build_console("  ", "  ") is None
+    assert scanners._build_console(None, None) is None
+
+
+def test_given_long_text_when_truncate_console_then_head_tail_preserved() -> None:
+    """
+    Scenario: _truncate_console preserves head and tail of long output.
+    Slice: _truncate_console — truncation
+
+    Given text longer than MAX_CONSOLE_CHARS,
+    When _truncate_console is called,
+    Then head and tail are preserved with an omission marker.
+    """
+    ### Given
+    text = "A" * 1000 + "MIDDLE" + "Z" * 3000
+
+    ### When
+    result = scanners._truncate_console(text, max_chars=200)
+
+    ### Then
+    assert result is not None
+    assert len(result) <= 250, "truncated result should be bounded"
+    assert result.startswith("A"), "head must be preserved"
+    assert result.endswith("Z"), "tail must be preserved"
+    assert "omitted" in result, "must include omission marker"
+
+
+def test_given_short_text_when_truncate_console_then_unchanged() -> None:
+    """
+    Scenario: _truncate_console returns short text as-is.
+    Slice: _truncate_console — passthrough
+
+    Given text shorter than max,
+    When _truncate_console is called,
+    Then result is the original text.
+    """
+    ### Given / When / Then
+    assert scanners._truncate_console("short", max_chars=3000) == "short"
+    assert scanners._truncate_console(None) is None
+
+
+def test_given_completed_with_console_when_building_row_then_console_output_in_row() -> None:
+    """
+    Scenario: Completed scanner rows carry console_output when provided.
+    Slice: _completed — console_output relay
+
+    Given findings and console output,
+    When _completed builds the row,
+    Then detail has the summary and console_output has the raw text.
+    """
+    ### Given
+    findings = [{"severity": "red", "message": "injection"}]
+    console = '{"findings": [{"severity": "red"}]}'
+
+    ### When
+    row = scanners._completed("Snyk", 1, findings, console_output=console)
+
+    ### Then
+    assert row["status"] == "completed"
+    assert "1 finding" in row["detail"]
+    assert row["console_output"] == console
+
+
+def test_given_completed_without_console_when_building_row_then_no_console_key() -> None:
+    """
+    Scenario: Completed scanner rows omit console_output when not provided.
+    Slice: _completed — no console_output
+
+    Given no console output,
+    When _completed builds the row,
+    Then console_output key is absent.
+    """
+    ### Given / When
+    row = scanners._completed("Snyk", 5, [])
+
+    ### Then
+    assert "console_output" not in row
+
+
+def test_given_callback_when_run_all_then_callback_called_per_scanner_group() -> None:
+    """
+    Scenario: on_scanner_done is called after each scanner group finishes.
+    Slice: run_all_scanners — incremental relay
+
+    Given mocked scanners and an on_scanner_done callback,
+    When run_all_scanners runs for a skill,
+    Then the callback is called once per scanner group with findings+rows.
+    """
+    ### Given
+    cisco_findings = [{"severity": "red", "message": "test", "scanner_source": "Cisco"}]
+    cisco_rows = [{"scanner_source": "Cisco", "status": "completed", "checks_run": 1}]
+    tessl_rows = [{"scanner_source": "Tessl", "status": "completed", "checks_run": 1}]
+    snyk_rows = [{"scanner_source": "Snyk", "status": "completed", "checks_run": 1}]
+    callback_calls = []
+
+    def on_done(findings, rows, quality_score=None):
+        callback_calls.append(
+            {"findings": findings, "rows": rows, "quality_score": quality_score}
+        )
+
+    ### When
+    with (
+        patch.object(
+            scanners, "run_cisco_skill_scanner", return_value=(cisco_findings, cisco_rows)
+        ),
+        patch.object(scanners, "run_tessl", return_value=(85.0, tessl_rows)),
+        patch.object(scanners, "run_snyk", return_value=([], snyk_rows)),
+    ):
+        result = scanners.run_all_scanners(
+            "/tmp/skill", "skill", "/tmp/skill", on_scanner_done=on_done
+        )
+
+    ### Then
+    assert len(callback_calls) == 3, "must call back once per scanner group (Cisco, Tessl, Snyk)"
+
+    assert callback_calls[0]["findings"] == cisco_findings
+    assert callback_calls[0]["rows"] == cisco_rows
+    assert callback_calls[0]["quality_score"] is None
+
+    assert callback_calls[1]["rows"] == tessl_rows
+    assert callback_calls[1]["quality_score"] == 85.0
+
+    assert callback_calls[2]["rows"] == snyk_rows
+
+    assert result["overall_status"] == "complete"
+    assert result["quality_score"] == 85.0
+
+
+def test_given_no_callback_when_run_all_then_works_unchanged() -> None:
+    """
+    Scenario: run_all_scanners without callback preserves backward compat.
+    Slice: run_all_scanners — no callback
+
+    Given mocked scanners and no callback,
+    When run_all_scanners runs,
+    Then results are returned normally without error.
+    """
+    ### Given / When
+    with (
+        patch.object(
+            scanners,
+            "run_cisco_mcp_scanner",
+            return_value=([], [{"scanner_source": "YARA", "status": "completed", "checks_run": 1}]),
+        ),
+        patch.object(
+            scanners, "run_snyk",
+            return_value=([], [{"scanner_source": "Snyk", "status": "completed", "checks_run": 1}]),
+        ),
+    ):
+        result = scanners.run_all_scanners("/tmp/mcp", "mcp_server", "https://example.com")
+
+    ### Then
+    assert result["overall_status"] == "complete"
+    assert len(result["scanner_rows"]) == 2
 
 
 def test_given_cisco_complete_and_tessl_unreachable_when_run_all_then_partial_failed() -> None:


### PR DESCRIPTION
## Summary

- **Sandbox:** Truncate and persist scanner stdout/stderr on runs; improve scan progress/status in `scan_app` / `scanners`; fix Snyk **skill** invocations (`--dangerously-run-mcp-servers` with `--skills`).
- **Dashboard:** Supabase **Realtime** refresh (`tripwire-realtime.js`); live run UI with **console**, **duration**, in-flight **SCANNING** state; expanded live/status tests.
- **Schema / CLI:** `db/schema.sql` + `ensureSchema` for console-related columns; tests for setup/`--force` behavior.
- **Docs:** Root README persona table and verified/Realtime sections; prototypes Live docs (chips, polling, drawer); `.env.example` Supabase ordering and note to re-apply schema after pulls.
- **Chore:** Ruff / ruff-format from pre-push.

## Documentation

Updated in this PR (README, prototypes/README, .env.example); no separate doc PR.

## Test Results

### Backend
**Tests**: 64 passed, 0 failed, 0 skipped (~0.16s)

**Coverage**:
| Module / Package | Statements |
|---|---|
| sandbox/__init__.py | 100% |
| sandbox/scan_app.py | 64% |
| sandbox/scanners.py | 49% |
| **Total** | **73%** |

### Frontend
**Tests**: 54 passed, 0 failed, 1 skipped (cli 18 + dc-dashboard 36 pass / 1 skip)

## Test plan

- [ ] Re-run `tripwire setup --force` if Supabase schema lacks `console_output` / `completed_at`
- [ ] Live dashboard: SCANNING card shows scanners + Modal console as they finish; Realtime chip when websocket connects
- [ ] Fixture scan with Snyk skill path uses correct CLI flags
- [ ] Mock dashboard still demos in-flight scanners without Supabase

Made with [Cursor](https://cursor.com)