### PR TITLE
test(slice-02): lock GWT-1 detection mapping for must-show items

### DIFF
--- a/docs/plan/PROGRESS.md
+++ b/docs/plan/PROGRESS.md
@@ -4,8 +4,8 @@
 ## Quick Status
 | # | Slice | MoSCoW | Status | Started | Completed | Est. time |
 |---|-------|--------|--------|---------|-----------|-----------|
-| 1 | [slice-1-walking-skeleton-live-path](slice-1-walking-skeleton-live-path.md) | Must | 🔀 | 2026-08-01 | — | ~50 min |
-| 2 | [slice-2-gwt1-detection-acceptance](slice-2-gwt1-detection-acceptance.md) | Must | 📋 | — | — | ~25 min |
+| 1 | [slice-1-walking-skeleton-live-path](slice-1-walking-skeleton-live-path.md) | Must | ✅ | 2026-08-01 | 2026-08-01 | ~50 min |
+| 2 | [slice-2-gwt1-detection-acceptance](slice-2-gwt1-detection-acceptance.md) | Must | 🔀 | 2026-08-01 | — | ~25 min |
 | 3 | [slice-3-gwt2-sandbox-evidence-acceptance](slice-3-gwt2-sandbox-evidence-acceptance.md) | Must | 📋 | — | — | ~25 min |
 | 4 | [slice-4-vo-remotion-assemble](slice-4-vo-remotion-assemble.md) | Must | 📋 | — | — | ~25 min |
 | 5 | [slice-5-gate-evidence-docs-sync](slice-5-gate-evidence-docs-sync.md) | Should | 📋 | — | — | ~25 min |
@@ -32,4 +32,5 @@
 ## Skill Execution Log
 | Date | Branch | Skill | Slice | Outcome | Notes |
 |------|--------|-------|-------|---------|-------|
-| 2026-08-01 | slice/1-walking-skeleton-live-path | nw-execute (adapted) | 1 | VERIFIED pending commit | Live scan + boolean probe; gate-evidence written |
+| 2026-08-01 | slice/1-walking-skeleton-live-path | nw-execute (adapted) | 1 | ✅ PASSED (PR #14) | Live scan + boolean probe; gate-evidence written |
+| 2026-08-01 | slice/2-gwt1-detection-acceptance | slice-workflow | 2 | VERIFIED pending commit | GWT-1 acceptance test added |

--- a/docs/plan/TRAIL.md
+++ b/docs/plan/TRAIL.md
@@ -76,8 +76,8 @@ freshness:
 ## Slices
 | # | File | Name | MoSCoW | Status | Depends on | Issue | Read time |
 |---|------|------|--------|--------|------------|-------|-----------|
-| 1 | [slice-1-walking-skeleton-live-path](slice-1-walking-skeleton-live-path.md) | Walking Skeleton — Live Demo Path | Must | 🔀 | none | — | ~5 min |
-| 2 | [slice-2-gwt1-detection-acceptance](slice-2-gwt1-detection-acceptance.md) | GWT-1 Detection Acceptance | Must | 📋 | 1 | — | ~4 min |
+| 1 | [slice-1-walking-skeleton-live-path](slice-1-walking-skeleton-live-path.md) | Walking Skeleton — Live Demo Path | Must | ✅ | none | #14 | ~5 min |
+| 2 | [slice-2-gwt1-detection-acceptance](slice-2-gwt1-detection-acceptance.md) | GWT-1 Detection Acceptance | Must | 🔀 | 1 | — | ~4 min |
 | 3 | [slice-3-gwt2-sandbox-evidence-acceptance](slice-3-gwt2-sandbox-evidence-acceptance.md) | GWT-2 Sandbox Evidence Acceptance | Must | 📋 | 1 | — | ~4 min |
 | 4 | [slice-4-vo-remotion-assemble](slice-4-vo-remotion-assemble.md) | VO + Remotion Assemble (GWT-3) | Must | 📋 | 2,3 | — | ~4 min |
 | 5 | [slice-5-gate-evidence-docs-sync](slice-5-gate-evidence-docs-sync.md) | Gate Evidence + Docs Sync | Should | 📋 | 1,2,3,4 | — | ~3 min |

--- a/docs/plan/gate-evidence/slice-2.json
+++ b/docs/plan/gate-evidence/slice-2.json
@@ -1,0 +1,14 @@
+{
+  "slice": "slice-2-gwt1-detection-acceptance",
+  "date": "2026-08-01",
+  "branch": "slice/2-gwt1-detection-acceptance",
+  "gwt": "GWT-1 Detection (must-show skill + MCP)",
+  "commands": [
+    {
+      "cmd": "cd prototypes/dc-dashboard && npm test",
+      "result": "38 tests, 37 pass, 1 skip, 0 fail"
+    }
+  ],
+  "acceptance_test": "given must-show skill and MCP live rows when loadData live then GWT-1 detection mapping holds",
+  "verdict": "VERIFIED"
+}

--- a/docs/plan/slice-1-walking-skeleton-live-path.md
+++ b/docs/plan/slice-1-walking-skeleton-live-path.md
@@ -69,7 +69,7 @@ On PASS: `gate_cache_write "fast" "$(git rev-parse HEAD)"` when applicable.
 | 14 | No orphaned file references | OK |
 
 ## Gate Status
-🔀 ON BRANCH — evidence VERIFIED; awaiting PR merge for ✅ PASSED
+✅ PASSED — merged via PR #14
 
 ## What Changed
 | File | Type | Reason |

--- a/docs/plan/slice-2-gwt1-detection-acceptance.md
+++ b/docs/plan/slice-2-gwt1-detection-acceptance.md
@@ -17,10 +17,10 @@
 **Then** heatmap status is non-grey for both; skill exposes file/line finding; MCP exposes affected tool name(s) (`entity_name` / `related_tool_names`)
 
 ## Before-Checks [GATE]
-- [ ] Branch created
-- [ ] Task file opened
-- [ ] Prior session recovery checked (if resuming)
-- [ ] Slice 1 evidence available (or fixture golden from slice 1)
+- [x] Branch created (`slice/2-gwt1-detection-acceptance`)
+- [x] Task file opened
+- [x] Prior session recovery checked (if resuming) — slice 1 ✅ via PR #14
+- [x] Slice 1 evidence available (`docs/plan/gate-evidence/slice-1.json`)
 
 ## TDD Execution
 UI/Feature outside-in: write failing acceptance/unit mapping tests first → GREEN → refactor.
@@ -29,13 +29,13 @@ Prefer fast unit tests against `tripwire-live.js` / status helpers with recorded
 VERIFY+COVERAGE: `cd prototypes/dc-dashboard && npm test` (and slow suite if added).
 
 ## After-Checks [GATE]
-- [ ] Code committed with `test(slice-2): ...`
-- [ ] Tests pass with coverage
-- [ ] Specification coverage: GWT-1 clauses have ≥1 test
-- [ ] Branch coverage target on touched modules
-- [ ] Mutation testing if feature-complete on touched logic
-- [ ] Acceptance criteria met
-- [ ] Docs updated
+- [x] Code committed with `test(slice-02): ...`
+- [x] Tests pass — 37 pass / 1 skip
+- [x] Specification coverage: GWT-1 clauses have ≥1 test
+- [x] Branch coverage target on touched modules — N/A test-only
+- [x] Mutation testing N/A — characterization/acceptance mapping only
+- [x] Acceptance criteria met
+- [x] Docs updated — gate-evidence/slice-2.json
 
 ## Doc Audit (14-row checklist)
 | # | Item | Check |
@@ -48,17 +48,19 @@ VERIFY+COVERAGE: `cd prototypes/dc-dashboard && npm test` (and slow suite if add
 | 6–14 | Remainder | N/A unless public API changes |
 
 ## Gate Status
-📋 PLANNED
+🔀 ON BRANCH — VERIFIED; awaiting PR merge
 
 ## What Changed
 | File | Type | Reason |
 |------|------|--------|
-| — | — | — |
+| prototypes/dc-dashboard/test/tripwire-live.test.js | test | GWT-1 must-show acceptance |
+| docs/plan/gate-evidence/slice-2.json | evidence | slice 2 gate |
+| docs/plan/TRAIL.md / PROGRESS.md | plan | slice 1 ✅ · slice 2 🔨 |
 
 ## Session Metrics
 | Metric | Value |
 |--------|-------|
 | Estimated Pomos | 1 (~25 min) |
-| Execution time | — |
+| Execution time | ~5 min |
 | Blockers encountered | — |
-| Next-session notes | — |
+| Next-session notes | `/clean-commit` then slice 3 |

--- a/prototypes/dc-dashboard/test/tripwire-live.test.js
+++ b/prototypes/dc-dashboard/test/tripwire-live.test.js
@@ -1053,6 +1053,126 @@ test('given schema sql when inspecting realtime then publication adds required t
     'schema must add findings to supabase_realtime publication');
 });
 
+// ── GWT-1 Detection (must-show #1+#2) — slice-2 ───────────────────────────
+
+test('given must-show skill and MCP live rows when loadData live then GWT-1 detection mapping holds', async () => {
+  /**
+   * Scenario: Live mapping exposes Detection evidence for shortlist skill + MCP.
+   * Slice: slice-2-gwt1-detection-acceptance
+   *
+   * Given heatmap + findings shaped like must-show #1+#2 scan results,
+   * When loadData maps Live Supabase rows into UI items,
+   * Then both items are non-grey; skill has file/line; MCP has tool name(s).
+   */
+  // -- Given --
+  const skillId = '11111111-1111-1111-1111-111111111111';
+  const mcpId = '22222222-2222-2222-2222-222222222222';
+  const skillRunId = '33333333-3333-3333-3333-333333333333';
+  const mcpRunId = '44444444-4444-4444-4444-444444444444';
+  installWindow({
+    SUPABASE_URL: 'https://proj.supabase.co',
+    SUPABASE_ANON_KEY: 'anon',
+  });
+  mockFetchByTable({
+    items: [
+      {
+        id: skillId,
+        type: 'skill',
+        name: 'vuln-prompt-injection-notes',
+        identifier: 'fixtures/skills/vuln-prompt-injection-notes',
+        heatmap_status: 'red',
+        risk_score: 2.0,
+        quality_score: null,
+        install_locus: 'local',
+        source_availability: 'source_on_disk',
+      },
+      {
+        id: mcpId,
+        type: 'mcp_server',
+        name: 'vuln-command-injection-server',
+        identifier: 'fixtures/mcp/vuln-command-injection-server',
+        heatmap_status: 'amber',
+        risk_score: 1.2,
+        quality_score: null,
+        install_locus: 'local',
+        source_availability: 'source_on_disk',
+      },
+    ],
+    scan_runs: [
+      {
+        id: skillRunId,
+        item_id: skillId,
+        status: 'complete',
+        started_at: '2026-08-01T18:00:00Z',
+        completed_at: '2026-08-01T18:01:00Z',
+      },
+      {
+        id: mcpRunId,
+        item_id: mcpId,
+        status: 'complete',
+        started_at: '2026-08-01T18:00:00Z',
+        completed_at: '2026-08-01T18:01:30Z',
+      },
+    ],
+    scan_run_scanners: [
+      { scan_run_id: skillRunId, scanner_source: 'Cisco Skill Scanner', status: 'completed', checks_run: 12 },
+      { scan_run_id: mcpRunId, scanner_source: 'Cisco MCP Scanner', status: 'completed', checks_run: 8 },
+    ],
+    findings: [
+      {
+        scan_run_id: skillRunId,
+        severity: 'red',
+        category: 'prompt_injection',
+        file_path: 'SKILL.md',
+        location: '12',
+        entity_kind: null,
+        entity_name: null,
+        scanner_source: 'Cisco Skill Scanner',
+        message: 'hidden SYSTEM OVERRIDE instruction block',
+        snippet: null,
+        cwe_ids: null,
+      },
+      {
+        scan_run_id: mcpRunId,
+        severity: 'red',
+        category: 'command_injection',
+        file_path: null,
+        location: null,
+        entity_kind: 'tool',
+        entity_name: 'run_shell',
+        scanner_source: 'Cisco MCP Scanner',
+        message: 'command injection surface on tool run_shell',
+        snippet: null,
+        cwe_ids: ['CWE-78'],
+      },
+    ],
+  });
+  const loadData = await importLoadDataFresh();
+
+  // -- When --
+  const result = await loadData('live');
+  const skill = result.data.items.find((i) => i.name === 'vuln-prompt-injection-notes');
+  const mcp = result.data.items.find((i) => i.name === 'vuln-command-injection-server');
+
+  // -- Then --
+  assert.equal(result.source, 'live', 'GWT-1 requires Live-mapped data, not mock');
+  assert.ok(skill, 'must-show skill item must be present');
+  assert.ok(mcp, 'must-show MCP item must be present');
+  assert.notEqual(skill.status, 'grey', 'skill heatmap/status must be non-grey');
+  assert.notEqual(mcp.status, 'grey', 'MCP heatmap/status must be non-grey');
+  assert.ok(
+    skill.findings.some((f) => f.file_path || f.location),
+    'skill Detection drill-down must expose file_path or location'
+  );
+  assert.ok(
+    mcp.findings.some(
+      (f) => f.entity_name || (Array.isArray(f.related_tool_names) && f.related_tool_names.length)
+    ),
+    'MCP Detection drill-down must expose entity_name or related_tool_names'
+  );
+  restoreFetch();
+});
+
 // ── Smoke / live helpers ──────────────────────────────────────────────────
 
 function hasLiveConfigForSmoke() {


### PR DESCRIPTION
## Summary
- test(slice-02): lock GWT-1 detection mapping for must-show items

## Test plan
- [x] Automated GWT-1 acceptance: must-show skill + MCP Live rows → non-grey status, skill file/line, MCP tool name
- [x] Gate evidence at `docs/plan/gate-evidence/slice-2.json`
- [x] Plan trackers: slice 1 ✅ (PR #14), slice 2 🔀

## Test Results

| Stack | Result |
|-------|--------|
| Python (`uv run pytest --cov`) | **64 passed**, 0 failed · line coverage **73%** (sandbox) |
| CLI (`cli` `npm test`) | **18 passed**, 0 failed |
| Dashboard (`prototypes/dc-dashboard` `npm test`) | **37 passed**, 0 failed, 1 skipped |

Coverage artifact: `.reports/coverage/coverage.json`

Made with [Cursor](https://cursor.com)