### PR TITLE
test(slice-03): lock GWT-2 sandbox evidence for must-show MCP

### DIFF
--- a/docs/plan/PROGRESS.md
+++ b/docs/plan/PROGRESS.md
@@ -1,12 +1,12 @@
 # Progress
-> Last updated: 2026-08-01
+> Last updated: 2026-08-02
 
 ## Quick Status
 | # | Slice | MoSCoW | Status | Started | Completed | Est. time |
 |---|-------|--------|--------|---------|-----------|-----------|
 | 1 | [slice-1-walking-skeleton-live-path](slice-1-walking-skeleton-live-path.md) | Must | ✅ | 2026-08-01 | 2026-08-01 | ~50 min |
-| 2 | [slice-2-gwt1-detection-acceptance](slice-2-gwt1-detection-acceptance.md) | Must | 🔀 | 2026-08-01 | — | ~25 min |
-| 3 | [slice-3-gwt2-sandbox-evidence-acceptance](slice-3-gwt2-sandbox-evidence-acceptance.md) | Must | 📋 | — | — | ~25 min |
+| 2 | [slice-2-gwt1-detection-acceptance](slice-2-gwt1-detection-acceptance.md) | Must | ✅ | 2026-08-01 | 2026-08-01 | ~25 min |
+| 3 | [slice-3-gwt2-sandbox-evidence-acceptance](slice-3-gwt2-sandbox-evidence-acceptance.md) | Must | 🔀 | 2026-08-02 | — | ~25 min |
 | 4 | [slice-4-vo-remotion-assemble](slice-4-vo-remotion-assemble.md) | Must | 📋 | — | — | ~25 min |
 | 5 | [slice-5-gate-evidence-docs-sync](slice-5-gate-evidence-docs-sync.md) | Should | 📋 | — | — | ~25 min |
 | 6 | [slice-6-orchestrator-characterization](slice-6-orchestrator-characterization.md) | Could | 📋 | — | — | ~25 min |
@@ -33,4 +33,5 @@
 | Date | Branch | Skill | Slice | Outcome | Notes |
 |------|--------|-------|-------|---------|-------|
 | 2026-08-01 | slice/1-walking-skeleton-live-path | nw-execute (adapted) | 1 | ✅ PASSED (PR #14) | Live scan + boolean probe; gate-evidence written |
-| 2026-08-01 | slice/2-gwt1-detection-acceptance | slice-workflow | 2 | VERIFIED pending commit | GWT-1 acceptance test added |
+| 2026-08-01 | slice/2-gwt1-detection-acceptance | slice-workflow | 2 | ✅ PASSED (PR #15) | GWT-1 acceptance test |
+| 2026-08-02 | slice/3-gwt2-sandbox-evidence-acceptance | slice-workflow | 3 | 🔀 ON BRANCH | GWT-2 sandbox evidence acceptance |

--- a/docs/plan/TRAIL.md
+++ b/docs/plan/TRAIL.md
@@ -77,8 +77,8 @@ freshness:
 | # | File | Name | MoSCoW | Status | Depends on | Issue | Read time |
 |---|------|------|--------|--------|------------|-------|-----------|
 | 1 | [slice-1-walking-skeleton-live-path](slice-1-walking-skeleton-live-path.md) | Walking Skeleton — Live Demo Path | Must | ✅ | none | #14 | ~5 min |
-| 2 | [slice-2-gwt1-detection-acceptance](slice-2-gwt1-detection-acceptance.md) | GWT-1 Detection Acceptance | Must | 🔀 | 1 | — | ~4 min |
-| 3 | [slice-3-gwt2-sandbox-evidence-acceptance](slice-3-gwt2-sandbox-evidence-acceptance.md) | GWT-2 Sandbox Evidence Acceptance | Must | 📋 | 1 | — | ~4 min |
+| 2 | [slice-2-gwt1-detection-acceptance](slice-2-gwt1-detection-acceptance.md) | GWT-1 Detection Acceptance | Must | ✅ | 1 | #15 | ~4 min |
+| 3 | [slice-3-gwt2-sandbox-evidence-acceptance](slice-3-gwt2-sandbox-evidence-acceptance.md) | GWT-2 Sandbox Evidence Acceptance | Must | 🔀 | 1 | — | ~4 min |
 | 4 | [slice-4-vo-remotion-assemble](slice-4-vo-remotion-assemble.md) | VO + Remotion Assemble (GWT-3) | Must | 📋 | 2,3 | — | ~4 min |
 | 5 | [slice-5-gate-evidence-docs-sync](slice-5-gate-evidence-docs-sync.md) | Gate Evidence + Docs Sync | Should | 📋 | 1,2,3,4 | — | ~3 min |
 | 6 | [slice-6-orchestrator-characterization](slice-6-orchestrator-characterization.md) | Orchestrator / Modal Characterization | Could | 📋 | none | — | ~3 min |
@@ -100,4 +100,3 @@ freshness:
 - Phase 4 Agent Guard
 - Phase 5 Reconciler / Overmind
 - Dashboard redesign / blast-radius / `--from-instructions`
-l

--- a/docs/plan/gate-evidence/slice-3.json
+++ b/docs/plan/gate-evidence/slice-3.json
@@ -1,0 +1,14 @@
+{
+  "slice": "slice-3-gwt2-sandbox-evidence-acceptance",
+  "date": "2026-08-02",
+  "branch": "slice/3-gwt2-sandbox-evidence-acceptance",
+  "gwt": "GWT-2 Sandbox evidence (must-show MCP)",
+  "commands": [
+    {
+      "cmd": "cd prototypes/dc-dashboard && npm test",
+      "result": "39 tests, 38 pass, 1 skip, 0 fail"
+    }
+  ],
+  "acceptance_test": "given must-show MCP completed scan_run when loadData live then GWT-2 sandbox evidence holds",
+  "verdict": "VERIFIED"
+}

--- a/docs/plan/slice-2-gwt1-detection-acceptance.md
+++ b/docs/plan/slice-2-gwt1-detection-acceptance.md
@@ -48,7 +48,7 @@ VERIFY+COVERAGE: `cd prototypes/dc-dashboard && npm test` (and slow suite if add
 | 6–14 | Remainder | N/A unless public API changes |
 
 ## Gate Status
-🔀 ON BRANCH — VERIFIED; awaiting PR merge
+✅ PASSED — PR #15 merged
 
 ## What Changed
 | File | Type | Reason |

--- a/docs/plan/slice-3-gwt2-sandbox-evidence-acceptance.md
+++ b/docs/plan/slice-3-gwt2-sandbox-evidence-acceptance.md
@@ -17,23 +17,23 @@
 **Then** sandbox evidence fields (id / timing / policy or egress phase as exposed today) are present and suitable for on-camera Sandbox beat — not empty when Live data is complete
 
 ## Before-Checks [GATE]
-- [ ] Branch created
-- [ ] Task file opened
-- [ ] Prior session recovery checked (if resuming)
-- [ ] Slice 1 evidence or golden payload available
+- [x] Branch created (`slice/3-gwt2-sandbox-evidence-acceptance`)
+- [x] Task file opened
+- [x] Prior session recovery checked — slice 1 ✅ (#14), slice 2 ✅ (#15)
+- [x] Slice 1 evidence available (`docs/plan/gate-evidence/slice-1.json`)
 
 ## TDD Execution
 Outside-in acceptance/unit mapping tests → GREEN → refactor.
 VERIFY+COVERAGE: `cd prototypes/dc-dashboard && npm test`.
 
 ## After-Checks [GATE]
-- [ ] Code committed with `test(slice-3): ...`
-- [ ] Tests pass with coverage
-- [ ] Specification coverage: GWT-2 clauses have ≥1 test
-- [ ] Branch coverage target on touched modules
-- [ ] Mutation testing if logic changed
-- [ ] Acceptance criteria met
-- [ ] Docs updated
+- [x] Code committed with `test(slice-03): ...`
+- [x] Tests pass — 38 pass / 1 skip
+- [x] Specification coverage: GWT-2 clauses have ≥1 test
+- [x] Branch coverage target on touched modules — N/A test-only
+- [x] Mutation testing N/A — characterization/acceptance mapping only
+- [x] Acceptance criteria met
+- [x] Docs updated — gate-evidence/slice-3.json
 
 ## Doc Audit (14-row checklist)
 | # | Item | Check |
@@ -41,17 +41,19 @@ VERIFY+COVERAGE: `cd prototypes/dc-dashboard && npm test`.
 | 1–14 | See slice-2 pattern | N/A unless behaviour change |
 
 ## Gate Status
-📋 PLANNED
+🔀 ON BRANCH — VERIFIED; awaiting PR merge
 
 ## What Changed
 | File | Type | Reason |
 |------|------|--------|
-| — | — | — |
+| prototypes/dc-dashboard/test/tripwire-live.test.js | test | GWT-2 must-show MCP sandbox acceptance |
+| docs/plan/gate-evidence/slice-3.json | evidence | slice 3 gate |
+| docs/plan/TRAIL.md / PROGRESS.md | plan | slice 2 ✅ · slice 3 🔀 |
 
 ## Session Metrics
 | Metric | Value |
 |--------|-------|
 | Estimated Pomos | 1 (~25 min) |
-| Execution time | — |
+| Execution time | ~5 min |
 | Blockers encountered | — |
-| Next-session notes | — |
+| Next-session notes | `/merge-pr-to-main` after approval; then slice 4 |

--- a/prototypes/dc-dashboard/test/tripwire-live.test.js
+++ b/prototypes/dc-dashboard/test/tripwire-live.test.js
@@ -1173,6 +1173,102 @@ test('given must-show skill and MCP live rows when loadData live then GWT-1 dete
   restoreFetch();
 });
 
+// ── GWT-2 Sandbox evidence (must-show MCP) — slice-3 ──────────────────────
+
+test('given must-show MCP completed scan_run when loadData live then GWT-2 sandbox evidence holds', async () => {
+  /**
+   * Scenario: Live mapping exposes Sandbox evidence for shortlist MCP.
+   * Slice: slice-3-gwt2-sandbox-evidence-acceptance
+   *
+   * Given a completed sandbox scan payload for vuln-command-injection-server,
+   * When loadData maps the latest scan_run into the UI item,
+   * Then sandbox id / timing / egress (or policy) fields are present for on-camera beat.
+   */
+  // -- Given --
+  const mcpId = '55555555-5555-5555-5555-555555555555';
+  const mcpRunId = '66666666-6666-6666-6666-666666666666';
+  installWindow({
+    SUPABASE_URL: 'https://proj.supabase.co',
+    SUPABASE_ANON_KEY: 'anon',
+  });
+  mockFetchByTable({
+    items: [
+      {
+        id: mcpId,
+        type: 'mcp_server',
+        name: 'vuln-command-injection-server',
+        identifier: 'fixtures/mcp/vuln-command-injection-server',
+        heatmap_status: 'amber',
+        risk_score: 1.2,
+        quality_score: null,
+        install_locus: 'local',
+        source_availability: 'source_on_disk',
+      },
+    ],
+    scan_runs: [
+      {
+        id: mcpRunId,
+        item_id: mcpId,
+        status: 'complete',
+        started_at: '2026-08-01T18:00:00Z',
+        completed_at: '2026-08-01T18:01:30Z',
+      },
+    ],
+    scan_run_scanners: [
+      {
+        scan_run_id: mcpRunId,
+        scanner_source: 'Cisco MCP Scanner',
+        status: 'completed',
+        checks_run: 8,
+        started_at: '2026-08-01T18:00:05Z',
+        completed_at: '2026-08-01T18:01:20Z',
+      },
+    ],
+    findings: [
+      {
+        scan_run_id: mcpRunId,
+        severity: 'red',
+        category: 'command_injection',
+        file_path: null,
+        location: null,
+        entity_kind: 'tool',
+        entity_name: 'run_shell',
+        scanner_source: 'Cisco MCP Scanner',
+        message: 'command injection surface on tool run_shell',
+        snippet: null,
+        cwe_ids: ['CWE-78'],
+      },
+    ],
+  });
+  const loadData = await importLoadDataFresh();
+
+  // -- When --
+  const result = await loadData('live');
+  const mcp = result.data.items.find((i) => i.name === 'vuln-command-injection-server');
+
+  // -- Then --
+  assert.equal(result.source, 'live', 'GWT-2 requires Live-mapped data, not mock');
+  assert.ok(mcp, 'must-show MCP item must be present');
+  assert.ok(mcp.sandbox, 'sandbox evidence panel must be populated when Live run is complete');
+  assert.ok(mcp.sandbox.id, 'sandbox identity (id) must be present for on-camera Sandbox beat');
+  assert.equal(mcp.sandbox.id, mcpRunId, 'sandbox id maps from latest scan_run id');
+  assert.ok(mcp.sandbox.started, 'sandbox started timing must be present');
+  assert.ok(mcp.sandbox.completed, 'sandbox completed timing must be present when run is complete');
+  assert.ok(
+    typeof mcp.sandbox.egressPhase === 'string' && mcp.sandbox.egressPhase.length > 0,
+    'sandbox egress/policy phase must be a non-empty string (camera-usable, not blank)'
+  );
+  assert.ok(
+    Array.isArray(mcp.scanners) && mcp.scanners.length > 0,
+    'scanner/policy evidence must be present alongside sandbox identity'
+  );
+  assert.ok(
+    mcp.scanners.some((s) => s.source && s.status),
+    'at least one scanner row must expose source + status for Sandbox beat'
+  );
+  restoreFetch();
+});
+
 // ── Smoke / live helpers ──────────────────────────────────────────────────
 
 function hasLiveConfigForSmoke() {


### PR DESCRIPTION
## Summary
- test(slice-03): lock GWT-2 sandbox evidence for must-show MCP

## Test plan
- [x] Automated GWT-2 acceptance: must-show MCP completed `scan_run` → Live sandbox id / timing / egressPhase + scanners
- [x] Gate evidence at `docs/plan/gate-evidence/slice-3.json`
- [x] Plan trackers: slice 2 ✅ (PR #15), slice 3 🔀

## Test Results

| Stack | Result |
|-------|--------|
| Python (`uv run pytest --cov`) | **64 passed**, 0 failed · line coverage **73%** (sandbox) |
| CLI (`cli` `npm test`) | **18 passed**, 0 failed |
| Dashboard (`prototypes/dc-dashboard` `npm test`) | **38 passed**, 0 failed, 1 skipped |

Coverage artifact: `.reports/coverage/coverage.json`

Made with [Cursor](https://cursor.com)