### PR TITLE
test(slice-06): lock orchestrator skip/force Modal spawn behaviour

### DIFF
--- a/cli/src/modalClient.js
+++ b/cli/src/modalClient.js
@@ -1,12 +1,13 @@
-import { spawn } from 'node:child_process';
+import { spawn as defaultSpawn } from 'node:child_process';
 
 // Spawns the Modal sandbox for one scan_run via the local entrypoint
 // (sandbox/scan_app.py::main). That host-side wrapper packs local directories into
 // a tar and passes bytes to remote scan_item — host paths are not on Modal's FS.
 // Do not invoke ::scan_item directly; that skips packing and leaves an empty workdir.
-export function spawnScanSandbox({ target, itemType, itemId, scanRunId }) {
+// `spawnImpl` is injectable for characterization tests (no live Modal).
+export function spawnScanSandbox({ target, itemType, itemId, scanRunId, spawnImpl = defaultSpawn }) {
   return new Promise((resolve, reject) => {
-    const proc = spawn('modal', [
+    const proc = spawnImpl('modal', [
       'run', 'sandbox/scan_app.py',
       '--target', target, '--item-type', itemType, '--item-id', itemId, '--scan-run-id', scanRunId
     ], { stdio: 'inherit' });

--- a/cli/src/orchestrator.js
+++ b/cli/src/orchestrator.js
@@ -61,9 +61,16 @@ async function upsertItem(supabase, target) {
   return { item: inserted, cached: false };
 }
 
-export async function runScan(targets, { concurrency = 5, force = false } = {}) {
-  await ensureSchema();
-  const supabase = getSupabase();
+export async function runScan(targets, {
+  concurrency = 5,
+  force = false,
+  // Injectable seams for characterization tests (defaults preserve production path).
+  ensureSchemaFn = ensureSchema,
+  getSupabaseFn = getSupabase,
+  spawnFn = spawnScanSandbox,
+} = {}) {
+  await ensureSchemaFn();
+  const supabase = getSupabaseFn();
   let batchId = null;
   if (targets.length > 1) {
     const { data: batch } = await supabase.from('scan_batches').insert({
@@ -84,7 +91,7 @@ export async function runScan(targets, { concurrency = 5, force = false } = {}) 
     if (runError) throw runError;
 
     try {
-      await spawnScanSandbox({ target: target.target, itemType: target.type, itemId: item.id, scanRunId: run.id });
+      await spawnFn({ target: target.target, itemType: target.type, itemId: item.id, scanRunId: run.id });
     } catch (err) {
       console.error(`[error] sandbox failed for ${target.target}: ${err.message}`);
       await supabase.from('scan_runs').update({ status: 'failed', completed_at: new Date().toISOString() }).eq('id', run.id);

--- a/cli/test/orchestrator-characterization.test.js
+++ b/cli/test/orchestrator-characterization.test.js
@@ -1,0 +1,263 @@
+/**
+ * Slice 6 — characterization of runScan idempotency + Modal spawn args.
+ * Locks current behaviour with mocked Supabase + spawn (no live Modal).
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { runScan } from '../src/orchestrator.js';
+import { spawnScanSandbox } from '../src/modalClient.js';
+import { hashLocalPath } from '../src/hash.js';
+
+function makeThenable(value) {
+  return {
+    then(resolve, reject) {
+      return Promise.resolve(value).then(resolve, reject);
+    },
+  };
+}
+
+/**
+ * Minimal fluent Supabase stub for upsertItem + runScan paths.
+ * `byHashItem` — when set, content_hash lookup returns cached item.
+ */
+function createSupabaseStub({ byHashItem = null, itemId = 'item-1', runId = 'run-1' } = {}) {
+  const calls = { insertScanRuns: 0, insertItems: 0, updateItems: 0, rpc: [] };
+
+  function chain(terminal) {
+    const api = {
+      select() { return api; },
+      eq() { return api; },
+      order() { return api; },
+      limit() { return api; },
+      single() { return makeThenable(terminal); },
+      maybeSingle() { return makeThenable(terminal); },
+      then: makeThenable(terminal).then.bind(makeThenable(terminal)),
+    };
+    return api;
+  }
+
+  const supabase = {
+    calls,
+    from(table) {
+      return {
+        select() {
+          if (table === 'items') {
+            // content_hash lookup → maybeSingle; identifier lookup → array
+            return {
+              eq(col) {
+                if (col === 'content_hash') {
+                  return {
+                    maybeSingle: () => makeThenable({ data: byHashItem, error: null }),
+                  };
+                }
+                if (col === 'identifier') {
+                  return {
+                    order() {
+                      return {
+                        limit() {
+                          return makeThenable({ data: [], error: null });
+                        },
+                      };
+                    },
+                  };
+                }
+                return chain({ data: null, error: null });
+              },
+            };
+          }
+          return chain({ data: null, error: null });
+        },
+        insert(row) {
+          if (table === 'items') {
+            calls.insertItems += 1;
+            return {
+              select() {
+                return {
+                  single: () => makeThenable({
+                    data: { id: itemId, ...row },
+                    error: null,
+                  }),
+                };
+              },
+            };
+          }
+          if (table === 'scan_runs') {
+            calls.insertScanRuns += 1;
+            return {
+              select() {
+                return {
+                  single: () => makeThenable({
+                    data: { id: runId, ...row },
+                    error: null,
+                  }),
+                };
+              },
+            };
+          }
+          if (table === 'scan_batches') {
+            return {
+              select() {
+                return {
+                  single: () => makeThenable({
+                    data: { id: 'batch-1', ...row },
+                    error: null,
+                  }),
+                };
+              },
+            };
+          }
+          return chain({ data: null, error: null });
+        },
+        update() {
+          if (table === 'items') calls.updateItems += 1;
+          return {
+            eq() {
+              return {
+                select() {
+                  return {
+                    single: () => makeThenable({
+                      data: byHashItem || { id: itemId },
+                      error: null,
+                    }),
+                  };
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+    rpc(name, args) {
+      calls.rpc.push({ name, args });
+      return makeThenable({ data: null, error: null });
+    },
+  };
+  return supabase;
+}
+
+async function withFixtureDir(fn) {
+  const dir = await mkdtemp(path.join(tmpdir(), 'tripwire-orch-'));
+  await writeFile(path.join(dir, 'SKILL.md'), '# fixture\n');
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test('given unchanged content_hash when runScan without force then skips spawn', async () => {
+  await withFixtureDir(async (dir) => {
+    const contentHash = await hashLocalPath(dir);
+    const item = {
+      id: 'cached-item',
+      identifier: dir,
+      content_hash: contentHash,
+    };
+    const supabase = createSupabaseStub({ byHashItem: item, itemId: item.id });
+    const spawnCalls = [];
+
+    await runScan(
+      [{ target: dir, type: 'skill', locus: 'local', avail: 'source_on_disk' }],
+      {
+        force: false,
+        ensureSchemaFn: async () => {},
+        getSupabaseFn: () => supabase,
+        spawnFn: async (args) => { spawnCalls.push(args); },
+      }
+    );
+
+    assert.equal(spawnCalls.length, 0, 'unchanged content must not spawn sandbox when not forced');
+    assert.equal(supabase.calls.insertScanRuns, 0, 'skip path must not insert scan_runs');
+  });
+});
+
+test('given unchanged content_hash when runScan with force then spawns with expected args shape', async () => {
+  await withFixtureDir(async (dir) => {
+    const contentHash = await hashLocalPath(dir);
+    const item = {
+      id: 'cached-item',
+      identifier: dir,
+      content_hash: contentHash,
+    };
+    const runId = 'forced-run';
+    const supabase = createSupabaseStub({ byHashItem: item, itemId: item.id, runId });
+    const spawnCalls = [];
+
+    await runScan(
+      [{ target: dir, type: 'skill', locus: 'local', avail: 'source_on_disk' }],
+      {
+        force: true,
+        ensureSchemaFn: async () => {},
+        getSupabaseFn: () => supabase,
+        spawnFn: async (args) => { spawnCalls.push(args); },
+      }
+    );
+
+    assert.equal(spawnCalls.length, 1, 'force must spawn even when content hash is unchanged');
+    assert.equal(supabase.calls.insertScanRuns, 1);
+    assert.deepEqual(spawnCalls[0], {
+      target: dir,
+      itemType: 'skill',
+      itemId: item.id,
+      scanRunId: runId,
+    });
+  });
+});
+
+test('given new content when runScan then inserts run and spawns sandbox', async () => {
+  await withFixtureDir(async (dir) => {
+    const supabase = createSupabaseStub({ byHashItem: null, itemId: 'new-item', runId: 'new-run' });
+    const spawnCalls = [];
+
+    await runScan(
+      [{ target: dir, type: 'mcp_server', locus: 'local', avail: 'source_on_disk' }],
+      {
+        force: false,
+        ensureSchemaFn: async () => {},
+        getSupabaseFn: () => supabase,
+        spawnFn: async (args) => { spawnCalls.push(args); },
+      }
+    );
+
+    assert.equal(supabase.calls.insertItems, 1);
+    assert.equal(supabase.calls.insertScanRuns, 1);
+    assert.equal(spawnCalls.length, 1);
+    assert.equal(spawnCalls[0].itemType, 'mcp_server');
+    assert.equal(spawnCalls[0].itemId, 'new-item');
+    assert.equal(spawnCalls[0].scanRunId, 'new-run');
+    assert.equal(spawnCalls[0].target, dir);
+  });
+});
+
+test('spawnScanSandbox invokes modal run scan_app.py with expected argv (mocked child_process)', async () => {
+  const spawned = [];
+  const fakeProc = new EventEmitter();
+  // exit asynchronously so listeners attach first
+  queueMicrotask(() => fakeProc.emit('exit', 0));
+
+  await spawnScanSandbox({
+    target: 'fixtures/mcp/vuln-command-injection-server',
+    itemType: 'mcp_server',
+    itemId: 'item-xyz',
+    scanRunId: 'run-xyz',
+    spawnImpl: (cmd, args, opts) => {
+      spawned.push({ cmd, args, opts });
+      return fakeProc;
+    },
+  });
+
+  assert.equal(spawned.length, 1);
+  assert.equal(spawned[0].cmd, 'modal');
+  assert.deepEqual(spawned[0].args, [
+    'run', 'sandbox/scan_app.py',
+    '--target', 'fixtures/mcp/vuln-command-injection-server',
+    '--item-type', 'mcp_server',
+    '--item-id', 'item-xyz',
+    '--scan-run-id', 'run-xyz',
+  ]);
+  assert.equal(spawned[0].opts.stdio, 'inherit');
+});

--- a/docs/plan/PROGRESS.md
+++ b/docs/plan/PROGRESS.md
@@ -9,7 +9,7 @@
 | 3 | [slice-3-gwt2-sandbox-evidence-acceptance](slice-3-gwt2-sandbox-evidence-acceptance.md) | Must | ✅ | 2026-08-02 | 2026-08-02 | ~25 min |
 | 4 | [slice-4-vo-remotion-assemble](slice-4-vo-remotion-assemble.md) | Must | 🔴 | 2026-08-02 | — | ~25 min |
 | 5 | [slice-5-gate-evidence-docs-sync](slice-5-gate-evidence-docs-sync.md) | Should | 📋 | — | — | ~25 min |
-| 6 | [slice-6-orchestrator-characterization](slice-6-orchestrator-characterization.md) | Could | 📋 | — | — | ~25 min |
+| 6 | [slice-6-orchestrator-characterization](slice-6-orchestrator-characterization.md) | Could | 🔀 | 2026-08-02 | — | ~25 min |
 
 **Status Legend**: `📋 PLANNED · 🔨 IN PROGRESS · ✅ PASSED · 🔀 ON BRANCH · 🔴 BLOCKED · 📦 DEFERRED`
 
@@ -35,4 +35,5 @@
 | 2026-08-01 | slice/1-walking-skeleton-live-path | nw-execute (adapted) | 1 | ✅ PASSED (PR #14) | Live scan + boolean probe; gate-evidence written |
 | 2026-08-01 | slice/2-gwt1-detection-acceptance | slice-workflow | 2 | ✅ PASSED (PR #15) | GWT-1 acceptance test |
 | 2026-08-02 | slice/3-gwt2-sandbox-evidence-acceptance | slice-workflow | 3 | ✅ PASSED (PR #16) | GWT-2 sandbox evidence acceptance |
-| 2026-08-02 | slice/4-vo-remotion-assemble | slice-workflow | 4 | 🔴 BLOCKED | Remotion sibling + VO assets missing |
+| 2026-08-02 | slice/4-vo-remotion-assemble | slice-workflow | 4 | 🔴 BLOCKED (PR #17) | Remotion sibling + VO assets missing |
+| 2026-08-02 | slice/6-orchestrator-characterization | slice-workflow | 6 | 🔀 ON BRANCH | skip/force spawn characterization |

--- a/docs/plan/TRAIL.md
+++ b/docs/plan/TRAIL.md
@@ -79,9 +79,9 @@ freshness:
 | 1 | [slice-1-walking-skeleton-live-path](slice-1-walking-skeleton-live-path.md) | Walking Skeleton — Live Demo Path | Must | ✅ | none | #14 | ~5 min |
 | 2 | [slice-2-gwt1-detection-acceptance](slice-2-gwt1-detection-acceptance.md) | GWT-1 Detection Acceptance | Must | ✅ | 1 | #15 | ~4 min |
 | 3 | [slice-3-gwt2-sandbox-evidence-acceptance](slice-3-gwt2-sandbox-evidence-acceptance.md) | GWT-2 Sandbox Evidence Acceptance | Must | ✅ | 1 | #16 | ~4 min |
-| 4 | [slice-4-vo-remotion-assemble](slice-4-vo-remotion-assemble.md) | VO + Remotion Assemble (GWT-3) | Must | 🔴 | 2,3 | — | ~4 min |
+| 4 | [slice-4-vo-remotion-assemble](slice-4-vo-remotion-assemble.md) | VO + Remotion Assemble (GWT-3) | Must | 🔴 | 2,3 | #17 | ~4 min |
 | 5 | [slice-5-gate-evidence-docs-sync](slice-5-gate-evidence-docs-sync.md) | Gate Evidence + Docs Sync | Should | 📋 | 1,2,3,4 | — | ~3 min |
-| 6 | [slice-6-orchestrator-characterization](slice-6-orchestrator-characterization.md) | Orchestrator / Modal Characterization | Could | 📋 | none | — | ~3 min |
+| 6 | [slice-6-orchestrator-characterization](slice-6-orchestrator-characterization.md) | Orchestrator / Modal Characterization | Could | 🔀 | none | — | ~3 min |
 
 **Status legend**: `📋 PLANNED · 🔨 IN PROGRESS · ✅ PASSED · 🔀 ON BRANCH · 🔴 BLOCKED · 📦 DEFERRED`
 

--- a/docs/plan/gate-evidence/slice-6.json
+++ b/docs/plan/gate-evidence/slice-6.json
@@ -1,0 +1,23 @@
+{
+  "slice": "slice-6-orchestrator-characterization",
+  "date": "2026-08-02",
+  "branch": "slice/6-orchestrator-characterization",
+  "gwt": "Orchestrator / Modal characterization (skip vs force spawn)",
+  "commands": [
+    {
+      "cmd": "cd cli && npm test",
+      "result": "22 tests, 22 pass, 0 fail"
+    }
+  ],
+  "acceptance_tests": [
+    "given unchanged content_hash when runScan without force then skips spawn",
+    "given unchanged content_hash when runScan with force then spawns with expected args shape",
+    "given new content when runScan then inserts run and spawns sandbox",
+    "spawnScanSandbox invokes modal run scan_app.py with expected argv (mocked child_process)"
+  ],
+  "seams": {
+    "runScan": "optional ensureSchemaFn / getSupabaseFn / spawnFn (defaults unchanged)",
+    "spawnScanSandbox": "optional spawnImpl (defaults to child_process.spawn)"
+  },
+  "verdict": "VERIFIED"
+}

--- a/docs/plan/slice-6-orchestrator-characterization.md
+++ b/docs/plan/slice-6-orchestrator-characterization.md
@@ -17,19 +17,23 @@
 **Then** unchanged content skips spawn when not forced; forced path invokes sandbox spawn with expected args shape
 
 ## Before-Checks [GATE]
-- [ ] Branch created
-- [ ] Task file opened
-- [ ] Prior session recovery checked (if resuming)
+- [x] Branch created (`slice/6-orchestrator-characterization`)
+- [x] Task file opened
+- [x] Prior session recovery checked — slice 4 🔴 Remotion blocked; PR #17 merged; continuing Could slice
 
 ## TDD Execution
 Backend inside-out characterization: assert current behaviour; do not “fix” product while greening.
 VERIFY+COVERAGE: `cd cli && npm test`.
 
+Injectable seams (defaults preserve production):
+- `runScan({ ensureSchemaFn, getSupabaseFn, spawnFn })`
+- `spawnScanSandbox({ spawnImpl })`
+
 ## After-Checks [GATE]
-- [ ] Tests committed
-- [ ] Coverage on touched modules
-- [ ] Acceptance criteria met
-- [ ] Docs N/A
+- [x] Tests committed with `test(slice-06): ...`
+- [x] Coverage on touched modules — cli suite 22/22
+- [x] Acceptance criteria met
+- [x] Docs — gate-evidence/slice-6.json
 
 ## Doc Audit (14-row checklist)
 | # | Item | Check |
@@ -37,17 +41,20 @@ VERIFY+COVERAGE: `cd cli && npm test`.
 | 1–14 | N/A for Could characterization unless API docs change | — |
 
 ## Gate Status
-📋 PLANNED
+🔀 ON BRANCH — VERIFIED; awaiting PR merge
 
 ## What Changed
 | File | Type | Reason |
 |------|------|--------|
-| — | — | — |
+| cli/src/orchestrator.js | seam | optional DI for characterization |
+| cli/src/modalClient.js | seam | optional spawnImpl |
+| cli/test/orchestrator-characterization.test.js | test | skip/force/spawn argv locks |
+| docs/plan/gate-evidence/slice-6.json | evidence | slice 6 gate |
 
 ## Session Metrics
 | Metric | Value |
 |--------|-------|
 | Estimated Pomos | 1 (~25 min) |
-| Execution time | — |
+| Execution time | ~15 min |
 | Blockers encountered | — |
-| Next-session notes | — |
+| Next-session notes | `/create-pr` then `/merge-pr-to-main`; slice 4 still 🔴 |


### PR DESCRIPTION
## Summary
- test(slice-06): lock orchestrator skip/force Modal spawn behaviour

## Test plan
- [x] Characterization: unchanged content_hash without force → skips spawn
- [x] Characterization: unchanged content_hash with force → spawn args shape locked
- [x] Characterization: new content → insert scan_run + spawn
- [x] `spawnScanSandbox` modal argv locked via mocked `child_process`
- [x] Gate evidence at `docs/plan/gate-evidence/slice-6.json`

## Test Results

| Stack | Result |
|-------|--------|
| Python (`uv run pytest --cov`) | **64 passed**, 0 failed · line coverage **73%** (sandbox) |
| CLI (`cli` `npm test`) | **22 passed**, 0 failed |
| Dashboard (`prototypes/dc-dashboard` `npm test`) | **39 passed**, 0 failed |

Coverage artifact: `.reports/coverage/coverage.json`

Made with [Cursor](https://cursor.com)