### PR TITLE
docs(plan): add ship-path coverage slices 7–14 and sync status

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,16 @@ pre-commit run --all-files          # lint, mypy, bandit, gitleaks, fast tests
 - **CI** (`.github/workflows/ci.yml`): Semgrep, OSV, Meterian, CodeQL, Trivy, TruffleHog
 - **Nightly** (`.github/workflows/nightly.yml`): mutmut, full TruffleHog, SBOM, Meterian, Chalk
 
+**Coverage today (VERIFIED config):** Python `fail_under=45` with `branch=true`
+(`pyproject.toml` / CI). CLI and `prototypes/dc-dashboard` tests run without a
+coverage gate.
+
+**Coverage target (DECIDED — slices 7–14):** ship-path ~95% on `cli/src`,
+`sandbox/`, and Live ACL modules (`tripwire-live.js` / `status` / `realtime` /
+`data`); `guard/` and `support.js` out of bar. Track progress in
+[docs/plan/PROGRESS.md](docs/plan/PROGRESS.md) and claims in
+[docs/STATUS.md](docs/STATUS.md).
+
 Intentional vuln fixtures under `fixtures/` and mock data under `prototypes/`
 are excluded from secrets scanners.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,9 +40,10 @@ Guides for **Tripwire**, by who you are and what you want to do.
 | Doc | What it covers |
 |-----|----------------|
 | [research/adapters/scanner-output-adapters.md](./research/adapters/scanner-output-adapters.md) | Scanner CLI output shapes (keep in sync with `sandbox/scanners.py`) |
-| [plan/PROGRESS.md](./plan/PROGRESS.md) | Slice status |
-| [plan/DECISIONS.md](./plan/DECISIONS.md) | Planning decisions |
-| [plan/TRAIL.md](./plan/TRAIL.md) | Execution trail |
+| [plan/PROGRESS.md](./plan/PROGRESS.md) | Slice status (Horizon A 1–6; coverage wave **7–14** 📋) |
+| [plan/DECISIONS.md](./plan/DECISIONS.md) | Planning decisions (incl. ship-path ~95% coverage) |
+| [plan/TRAIL.md](./plan/TRAIL.md) | Execution trail + context pack (`internal-docs/00_build/`) |
+| [plan/slice-7-coverage-audit-matrix.md](./plan/slice-7-coverage-audit-matrix.md) | Next Must: coverage audit (then 8–14) |
 
 ---
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -58,11 +58,29 @@ Reachable through production entry points / config:
 
 ---
 
+## DECIDED (not yet IMPLEMENTED / VERIFIED)
+
+Ship-path coverage uplift (~95% instrumented on `cli/src`, `sandbox/`, Live ACL JS;
+omit `guard/` and `support.js`) — planning slices **7–14** on branch
+`plan/coverage-slices-7-14`. See [plan/PROGRESS.md](./plan/PROGRESS.md),
+[plan/DECISIONS.md](./plan/DECISIONS.md), and slice stubs
+`docs/plan/slice-7-*.md` … `slice-14-*.md`.
+
+Current CI Python floor remains **`fail_under=45`** (`pyproject.toml` / CI) with
+measured ~47% (2026-08-02). Node CLI and dashboard have **no** coverage gate yet.
+Do not treat 95% as current capability until slices 11–13 are VERIFIED.
+
+Live Modal/Supabase E2E as a CI Must remains **Won't** for this wave (slow/optional
+skip-without-config stays).
+
+---
+
 ## RESEARCH (not VERIFIED)
 
 Exact JSON field names in `sandbox/scanners.py` — cross-check against the pinned
 CLI version's `--help`/output before this blocks a merge. See
 [scanner-output-adapters.md](./research/adapters/scanner-output-adapters.md).
+Adapter fixture tests (slices 8–9) are planned to tighten this.
 
 ---
 
@@ -71,6 +89,9 @@ CLI version's `--help`/output before this blocks a merge. See
 Known fixture gaps (not urgent) are listed under
 [fixtures/README.md](../fixtures/README.md) (“Not yet built”). Do not treat those
 as shipped capabilities.
+
+Coverage audit matrix artifact (`docs/plan/coverage-audit.md`) is owned by
+slice 7 — not written yet.
 
 ---
 

--- a/docs/plan/DECISIONS.md
+++ b/docs/plan/DECISIONS.md
@@ -24,3 +24,9 @@
 | 2026-08-01 | nw-execute adapt | docs/plan slice-workflow | No `.nwave/config.yaml`/roadmap; execute TRAIL slices via slice stubs + TDD |
 | 2026-08-02 | slice-4 blocker | Remotion sibling missing | `claude-remotion-kickstart` not on disk / not listed under neomatrix369; VO assets absent in internal-docs; GWT-3 script audit PASS in-repo |
 | 2026-08-02 | slice-5 entry | Waive “slices 1–4 complete” | Slice 4 remains 🔴; proceed with docs sync for verified 1–3 (+6) and leave VO/capture open in build-day |
+| 2026-08-02 | coverage-target | Ship-path ~95% instrumented | User locked; behavior matrix primary; floors after Must ATs |
+| 2026-08-02 | coverage-scope | Ship path only | cli/src + sandbox (excl tests) + Live ACL JS; omit guard, support.js, Remotion, scripts |
+| 2026-08-02 | coverage-e2e | Live Modal/Supabase CI Must = Won't | Stay slow/optional skip-without-config |
+| 2026-08-02 | planning | Added slices 7–14 | Path B Add via enhanced-flow-planner; delta-only vs existing suites; internal-docs context pack mandatory |
+| 2026-08-02 | health-check | Gap 2: Routing fingerprint | AUTO-FIXED on TRAIL Original Material |
+| 2026-08-02 | sync-docs | Coverage wave docs | STATUS DECIDED + CONTRIBUTING floors + docs/README plan links; README NO_CHANGE |

--- a/docs/plan/PROGRESS.md
+++ b/docs/plan/PROGRESS.md
@@ -10,6 +10,14 @@
 | 4 | [slice-4-vo-remotion-assemble](slice-4-vo-remotion-assemble.md) | Must | 🔴 | 2026-08-02 | — | ~25 min |
 | 5 | [slice-5-gate-evidence-docs-sync](slice-5-gate-evidence-docs-sync.md) | Should | ✅ | 2026-08-02 | 2026-08-02 | ~25 min |
 | 6 | [slice-6-orchestrator-characterization](slice-6-orchestrator-characterization.md) | Could | ✅ | 2026-08-02 | 2026-08-02 | ~25 min |
+| 7 | [slice-7-coverage-audit-matrix](slice-7-coverage-audit-matrix.md) | Must | 📋 | — | — | ~25 min |
+| 8 | [slice-8-scanner-skill-parse-fixtures](slice-8-scanner-skill-parse-fixtures.md) | Must | 📋 | — | — | ~25 min |
+| 9 | [slice-9-scanner-snyk-tessl-parse-fixtures](slice-9-scanner-snyk-tessl-parse-fixtures.md) | Must | 📋 | — | — | ~25 min |
+| 10 | [slice-10-scan-item-inner-characterization](slice-10-scan-item-inner-characterization.md) | Must | 📋 | — | — | ~25 min |
+| 11 | [slice-11-python-ship-path-coverage-95](slice-11-python-ship-path-coverage-95.md) | Must | 📋 | — | — | ~50 min |
+| 12 | [slice-12-cli-coverage-gate-95](slice-12-cli-coverage-gate-95.md) | Must | 📋 | — | — | ~25 min |
+| 13 | [slice-13-live-acl-coverage-gate-95](slice-13-live-acl-coverage-gate-95.md) | Must | 📋 | — | — | ~25 min |
+| 14 | [slice-14-coverage-status-docs-sync](slice-14-coverage-status-docs-sync.md) | Should | 📋 | — | — | ~25 min |
 
 **Status Legend**: `📋 PLANNED · 🔨 IN PROGRESS · ✅ PASSED · 🔀 ON BRANCH · 🔴 BLOCKED · 📦 DEFERRED`
 
@@ -19,9 +27,10 @@
 | 4 | Sibling Remotion repo `claude-remotion-kickstart` (branch `video/tripwire`) not found on disk or under `neomatrix369` GitHub; no VO audio/transcript/render artifacts in `internal-docs/01_demo_video/` | 🔴 open — need path or clone URL |
 
 ## Forward Roadmap
-- After A: ask whether to expand to **1+C** (product Phase 3 full + Guard/Reconciler as Should).
-- Won't for A: Drift demo, Phase 4/5, redesign, blast-radius, instruction→install→scan.
-- Horizon A open: unblock slice 4 (VO/Remotion) for done=2b.
+- Next execute: **slice 7** (coverage audit) on branch `plan/coverage-slices-7-14` then per-slice branches as needed.
+- After coverage wave (7–14): ask whether to expand to **1+C** (product Phase 3 full + Guard/Reconciler as Should).
+- Won't for A: Drift demo, Phase 4/5, redesign, blast-radius, instruction→install→scan; Live E2E CI Must; support.js 95%.
+- Horizon A open: unblock slice 4 (VO/Remotion) for done=2b (independent of coverage wave).
 
 ## Interrupt Recovery
 1. Read **Quick Status** — find 🔨 IN PROGRESS or 🔴 BLOCKED
@@ -39,3 +48,4 @@
 | 2026-08-02 | slice/4-vo-remotion-assemble | slice-workflow | 4 | 🔴 BLOCKED (PR #17) | Remotion sibling + VO assets missing |
 | 2026-08-02 | slice/6-orchestrator-characterization | slice-workflow | 6 | ✅ PASSED (PR #18) | skip/force spawn characterization |
 | 2026-08-02 | slice/5-gate-evidence-docs-sync | slice-workflow | 5 | ✅ PASSED (PR #19) | build-day 3-lite sync; slice 4 waived |
+| 2026-08-02 | plan/coverage-slices-7-14 | enhanced-flow-planner Add | 7–14 | 📋 stubs written | ship-path ~95%; delta-only; internal-docs context pack |

--- a/docs/plan/TRAIL.md
+++ b/docs/plan/TRAIL.md
@@ -2,9 +2,10 @@
 > ~8 min read
 
 ## Original Material
-- **Brief**: Horizon A — gap-close Saturday 3-lite + demo video (Detection + Sandbox). Operator reports capture-ready; formalize GWT evidence, dress-rehearsal, VO/Remotion. Expand to 1+C later.
+- **Brief**: Horizon A — gap-close Saturday 3-lite + demo video (Detection + Sandbox). Operator reports capture-ready; formalize GWT evidence, dress-rehearsal, VO/Remotion. Expand to 1+C later. **Wave +coverage**: ship-path ~95% (cli + sandbox + Live ACL); slices 7–14.
 - **Scenario**: Brownfield · Flow D · depth 5–8
-- **Canonical plan path**: `docs/plan/` (public). Product SoT remains gitignored `internal-docs/00_build/` — do not fork parallel plan trees.
+- **Routing:** Brownfield · Chosen: 2026-08-02 · Source: health-check-inferred
+- **Canonical plan path**: `docs/plan/` (public). Product SoT remains gitignored `internal-docs/00_build/` — do not fork parallel plan trees. Enhanced-flow-planner context pack: `internal-docs/00_build/*` + `01_demo_video/00-tripwire-demo-script.md` (not `02_prototypes/import-stash/`).
 - **Model split** — Planning: claude-opus-4-8 · Execution: claude-sonnet-5 · Design: N/A (UI frozen as-is)
 
 <!-- harness-scout output -->
@@ -82,6 +83,14 @@ freshness:
 | 4 | [slice-4-vo-remotion-assemble](slice-4-vo-remotion-assemble.md) | VO + Remotion Assemble (GWT-3) | Must | 🔴 | 2,3 | #17 | ~4 min |
 | 5 | [slice-5-gate-evidence-docs-sync](slice-5-gate-evidence-docs-sync.md) | Gate Evidence + Docs Sync | Should | ✅ | 1,2,3,4 | #19 | ~3 min |
 | 6 | [slice-6-orchestrator-characterization](slice-6-orchestrator-characterization.md) | Orchestrator / Modal Characterization | Could | ✅ | none | #18 | ~3 min |
+| 7 | [slice-7-coverage-audit-matrix](slice-7-coverage-audit-matrix.md) | Coverage Audit Matrix + Docs Parity | Must | 📋 | none | — | ~4 min |
+| 8 | [slice-8-scanner-skill-parse-fixtures](slice-8-scanner-skill-parse-fixtures.md) | Scanner Skill Parse Fixtures (Delta) | Must | 📋 | 7 | — | ~4 min |
+| 9 | [slice-9-scanner-snyk-tessl-parse-fixtures](slice-9-scanner-snyk-tessl-parse-fixtures.md) | Snyk / Tessl Parse Fixtures (Delta) | Must | 📋 | 7 | — | ~4 min |
+| 10 | [slice-10-scan-item-inner-characterization](slice-10-scan-item-inner-characterization.md) | scan_item_inner Characterization (Delta) | Must | 📋 | 7 | — | ~4 min |
+| 11 | [slice-11-python-ship-path-coverage-95](slice-11-python-ship-path-coverage-95.md) | Python Ship-Path Coverage ≥95% | Must | 📋 | 8,9,10 | — | ~5 min |
+| 12 | [slice-12-cli-coverage-gate-95](slice-12-cli-coverage-gate-95.md) | CLI Coverage Gate ≥95% (Delta) | Must | 📋 | 6 | — | ~4 min |
+| 13 | [slice-13-live-acl-coverage-gate-95](slice-13-live-acl-coverage-gate-95.md) | Live ACL Coverage Gate ≥95% (Delta) | Must | 📋 | 2,3 | — | ~4 min |
+| 14 | [slice-14-coverage-status-docs-sync](slice-14-coverage-status-docs-sync.md) | Coverage Status + Docs Sync (Delta) | Should | 📋 | 11,12,13 | — | ~3 min |
 
 **Status legend**: `📋 PLANNED · 🔨 IN PROGRESS · ✅ PASSED · 🔀 ON BRANCH · 🔴 BLOCKED · 📦 DEFERRED`
 
@@ -91,12 +100,15 @@ freshness:
 | interview_summary.md | ✅ written |
 | PROGRESS.md | ✅ written |
 | DECISIONS.md | ✅ in progress |
+| coverage-audit.md | 📋 pending — slice 7 |
 | GAP_ANALYSIS.md | pending |
 | HANDOFF.md | pending — `/memory-distiller` at session end |
-| gate-evidence/ | pending at slice PASS |
+| gate-evidence/ | ✅ slices 1–6; 7–14 at each PASS |
 
 ## Forward (Won't for A — ask 1+C later)
 - Drift / trend / diff / `identifier` UI
-- Phase 4 Agent Guard
+- Phase 4 Agent Guard (also excluded from ship-path coverage bar)
 - Phase 5 Reconciler / Overmind
 - Dashboard redesign / blast-radius / `--from-instructions`
+- `support.js` / Mock chrome 95% coverage
+- Live Modal/Supabase E2E as CI Must (stay slow/optional)

--- a/docs/plan/slice-10-scan-item-inner-characterization.md
+++ b/docs/plan/slice-10-scan-item-inner-characterization.md
@@ -1,0 +1,49 @@
+# Slice 10: scan_item_inner Characterization (Delta)
+
+> Scenario: Brownfield | MoSCoW: Must
+
+## Slice Workflow Bundle
+- Slice name: slice-10-scan-item-inner-characterization
+- Files: `sandbox/scan_app.py`, `sandbox/test_scan_app.py` (extend) or new `test_scan_item_inner.py`
+- Exit criteria: Characterization locks `_scan_item_inner` scanner start/done + fail marks with mocked Supabase + stubbed `run_all_scanners`.
+- Commit pattern: `test(slice-10): scan_item_inner characterization`
+
+## Branch
+`slice/10-scan-item-inner-characterization`
+
+## Context references (mandatory)
+- Product SoT: `internal-docs/00_build/security-scanning-platform-spec.md` (sandbox → Supabase writes)
+- Build gates: `internal-docs/00_build/build-day-decisions.md`
+- Audit: `docs/plan/coverage-audit.md`
+- Code: `sandbox/scan_app.py`
+
+## Spec (GWT / User Story)
+**Given** mocked Supabase client and stubbed `run_all_scanners`
+**When** `_scan_item_inner` runs success and scanner-failure paths
+**Then** scanner row updates / fail marks match today’s contract (including PGRST204-safe update usage already implemented)
+
+## Out of scope (already exists)
+- Unit tests for `_safe_insert` / `_safe_update` / `_is_column_error` / `_to_runtime_error` in `test_scan_app.py`
+- `_acquire_target` suite (`test_acquire_target.py`)
+
+## Before-Checks [GATE]
+- [ ] Branch created
+- [ ] Slice 7 available
+- [ ] Confirmed `scan_item` / `_scan_item_inner` still have no direct tests
+
+## TDD Execution
+Characterization: lock current behaviour; do not “fix” product while greening.
+VERIFY: `pytest sandbox/ -q --tb=short`
+
+## After-Checks [GATE]
+- [ ] Tests pass
+- [ ] Specification coverage: start/done/fail paths for inner scan
+- [ ] Gate evidence `slice-10.json` at PASS
+
+## Gate Status
+📋 PLANNED
+
+## Session Metrics
+| Metric | Value |
+|--------|-------|
+| Estimated Pomos | 1 (~25 min) |

--- a/docs/plan/slice-11-python-ship-path-coverage-95.md
+++ b/docs/plan/slice-11-python-ship-path-coverage-95.md
@@ -1,0 +1,51 @@
+# Slice 11: Python Ship-Path Coverage ≥95%
+
+> Scenario: Brownfield | MoSCoW: Must
+
+## Slice Workflow Bundle
+- Slice name: slice-11-python-ship-path-coverage-95
+- Files: `pyproject.toml`, `.github/workflows/ci.yml`, `sandbox/` (tests only if residual holes), omit `guard` from ship-path coverage source
+- Exit criteria: Ship-path sandbox measured ≥95% (branch where configured); CI `fail_under=95`; `guard/` excluded from denominator; residual &lt;5% only via justified reviewed excludes.
+- Commit pattern: `ci(slice-11): python ship-path coverage 95`
+
+## Branch
+`slice/11-python-ship-path-coverage-95`
+
+## Context references (mandatory)
+- Audit: `docs/plan/coverage-audit.md`
+- Spec / build-day: `internal-docs/00_build/` (Phase 4 Guard = out of bar)
+- Config: `pyproject.toml`, `.github/workflows/ci.yml`
+
+## Spec (GWT / User Story)
+**Given** slices 8–10 green and guard treated as Phase 4 bonus
+**When** coverage is measured on ship-path sandbox only
+**Then** ≥95% and CI enforces it; guard is not in the fail_under denominator
+
+## Out of scope
+- Guard Phase 4 tests
+- Node/CLI/dashboard coverage (slices 12–13)
+- Bulk `pragma: no cover` on scanners
+
+## Before-Checks [GATE]
+- [ ] Branch created
+- [ ] Slices 8, 9, 10 ✅
+- [ ] Baseline coverage re-measured after 8–10
+
+## TDD Execution
+[Walking Skeleton — 2 Pomos] Measure → fill residual holes with high-level tests → raise floor stepwise if needed (70→90→95) in this slice’s commits → final fail_under=95.
+
+VERIFY: `pytest sandbox/ --cov=sandbox --cov-fail-under=95` (guard omitted from source)
+
+## After-Checks [GATE]
+- [ ] `fail_under=95` in pyproject + CI
+- [ ] guard omitted from ship-path coverage source
+- [ ] Measured ≥95% on sandbox
+- [ ] Gate evidence `slice-11.json` at PASS
+
+## Gate Status
+📋 PLANNED
+
+## Session Metrics
+| Metric | Value |
+|--------|-------|
+| Estimated Pomos | 2 (~50 min) [Walking Skeleton] |

--- a/docs/plan/slice-12-cli-coverage-gate-95.md
+++ b/docs/plan/slice-12-cli-coverage-gate-95.md
@@ -1,0 +1,48 @@
+# Slice 12: CLI Coverage Gate ≥95% (Delta)
+
+> Scenario: Brownfield | MoSCoW: Must
+
+## Slice Workflow Bundle
+- Slice name: slice-12-cli-coverage-gate-95
+- Files: `cli/package.json`, `cli/test/*`, `.github/workflows/ci.yml` (cli-tests job)
+- Exit criteria: Coverage tool (e.g. `c8`) on `cli/src/**`; CI gate ≥95%; tests added only for uncovered ship paths.
+- Commit pattern: `ci(slice-12): cli coverage gate 95`
+
+## Branch
+`slice/12-cli-coverage-gate-95`
+
+## Context references (mandatory)
+- Audit: `docs/plan/coverage-audit.md`
+- Spec Done-when Phase 1 CLI: `internal-docs/00_build/security-scanning-platform-spec.md`
+- Existing tests: `cli/test/*` (incl. slice 6 characterization)
+
+## Spec (GWT / User Story)
+**Given** existing CLI unit/characterization suite and no coverage gate
+**When** coverage is instrumented on `cli/src`
+**Then** CI fails below 95%; any holes filled with high-level tests first
+
+## Out of scope (already exists)
+- Replacing discovery/hash/ensureSchema/orchestrator characterization suites
+- Live Modal integration tests as CI Must
+
+## Before-Checks [GATE]
+- [ ] Branch created
+- [ ] Slice 6 ✅ (characterization seams available)
+- [ ] Confirm no c8/nyc gate in cli package.json
+
+## TDD Execution
+Add instrumentation → measure → fill uncovered modules → gate 80 then 95 (or direct 95 if already close).
+VERIFY: `cd cli && npm test` (with coverage script)
+
+## After-Checks [GATE]
+- [ ] CI cli-tests enforces ≥95% on `cli/src`
+- [ ] Tests pass
+- [ ] Gate evidence `slice-12.json` at PASS
+
+## Gate Status
+📋 PLANNED
+
+## Session Metrics
+| Metric | Value |
+|--------|-------|
+| Estimated Pomos | 1 (~25 min) |

--- a/docs/plan/slice-13-live-acl-coverage-gate-95.md
+++ b/docs/plan/slice-13-live-acl-coverage-gate-95.md
@@ -1,0 +1,50 @@
+# Slice 13: Live ACL Coverage Gate ≥95% (Delta)
+
+> Scenario: Brownfield | MoSCoW: Must
+
+## Slice Workflow Bundle
+- Slice name: slice-13-live-acl-coverage-gate-95
+- Files: `prototypes/dc-dashboard/package.json`, `tripwire-live.js`, `tripwire-status.js`, `tripwire-realtime.js`, `tripwire-data.js`, `test/*`, CI if dashboard tests run in CI
+- Exit criteria: Coverage on Live ACL modules only ≥95%; **not** `support.js` / Mock chrome; hole-fill only.
+- Commit pattern: `ci(slice-13): live acl coverage gate 95`
+
+## Branch
+`slice/13-live-acl-coverage-gate-95`
+
+## Context references (mandatory)
+- Demo lens: `internal-docs/01_demo_video/00-tripwire-demo-script.md` (Detection + Sandbox must-show)
+- Spec: `internal-docs/00_build/security-scanning-platform-spec.md`
+- Audit: `docs/plan/coverage-audit.md`
+- Existing ATs: slices 2–3 (`tripwire-live.test.js`, status tests)
+
+## Spec (GWT / User Story)
+**Given** GWT-1/2 mapping tests and no coverage gate on ACL modules
+**When** coverage is gated on the four Live ACL files
+**Then** CI (or documented npm script enforced in CI) fails below 95%; support.js excluded
+
+## Out of scope (already exists)
+- Rewriting GWT-1/2 acceptance mapping tests
+- Covering `support.js` / `Tripwire.dc.html` presentation
+- Live Modal/Supabase E2E as CI Must (Won't)
+
+## Before-Checks [GATE]
+- [ ] Branch created
+- [ ] Slices 2–3 ✅
+- [ ] Confirm no coverage gate in dc-dashboard package.json
+
+## TDD Execution
+Instrument ACL modules → measure → fill holes → gate ≥95%.
+VERIFY: `cd prototypes/dc-dashboard && npm test` (with coverage)
+
+## After-Checks [GATE]
+- [ ] ≥95% on ACL file set; support.js excluded
+- [ ] Tests pass
+- [ ] Gate evidence `slice-13.json` at PASS
+
+## Gate Status
+📋 PLANNED
+
+## Session Metrics
+| Metric | Value |
+|--------|-------|
+| Estimated Pomos | 1 (~25 min) |

--- a/docs/plan/slice-14-coverage-status-docs-sync.md
+++ b/docs/plan/slice-14-coverage-status-docs-sync.md
@@ -1,0 +1,48 @@
+# Slice 14: Coverage Status + Docs Sync (Delta)
+
+> Scenario: Brownfield | MoSCoW: Should
+
+## Slice Workflow Bundle
+- Slice name: slice-14-coverage-status-docs-sync
+- Files: `docs/STATUS.md`, `docs/plan/PROGRESS.md`, `docs/plan/DECISIONS.md`, `CONTRIBUTING.md` (coverage floors), optional `internal-docs/00_build/build-day-decisions.md` (local)
+- Exit criteria: STATUS VERIFIED cites new suites; coverage floors documented; no redo of slice-5 scope.
+- Commit pattern: `docs(slice-14): sync status after coverage uplift`
+
+## Branch
+`slice/14-coverage-status-docs-sync`
+
+## Context references (mandatory)
+- Product SoT: `internal-docs/00_build/security-scanning-platform-spec.md`
+- Build gates: `internal-docs/00_build/build-day-decisions.md`
+- Adapter research sync if field names verified: `internal-docs/00_build/research/` ↔ `docs/research/adapters/`
+- Evidence: `docs/STATUS.md`, `docs/plan/coverage-audit.md`
+
+## Spec (GWT / User Story)
+**Given** slices 11–13 PASSED with measured ≥95% ship-path gates
+**When** docs are synced
+**Then** STATUS evidence labels cite the new suites/commands; CONTRIBUTING/CI comments state floors; build-day boxes stay honest
+
+## Out of scope (already exists)
+- Slice 5 gate-evidence backfill for slices 1–6
+- Unblocking Remotion/slice 4
+
+## Before-Checks [GATE]
+- [ ] Branch created
+- [ ] Slices 11, 12, 13 ✅
+- [ ] coverage-audit.md updated with final numbers
+
+## TDD Execution
+Docs-only.
+
+## After-Checks [GATE]
+- [ ] STATUS/PROGRESS/DECISIONS updated
+- [ ] Acceptance criteria met
+- [ ] Gate evidence `slice-14.json` at PASS
+
+## Gate Status
+📋 PLANNED
+
+## Session Metrics
+| Metric | Value |
+|--------|-------|
+| Estimated Pomos | 1 (~25 min) |

--- a/docs/plan/slice-7-coverage-audit-matrix.md
+++ b/docs/plan/slice-7-coverage-audit-matrix.md
@@ -1,0 +1,61 @@
+# Slice 7: Coverage Audit Matrix + Docs Parity
+
+> Scenario: Brownfield | MoSCoW: Must
+
+## Slice Workflow Bundle
+- Slice name: slice-7-coverage-audit-matrix
+- Files: `docs/plan/coverage-audit.md`, `docs/plan/DECISIONS.md`, `docs/plan/TRAIL.md`
+- Exit criteria: `coverage-audit.md` exists with ship-path behavior matrix + internal-docs↔docs parity deltas + altitude notes; no CI floor raise in this slice.
+- Commit pattern: `docs(slice-7): coverage audit matrix and parity`
+
+## Branch
+`slice/7-coverage-audit-matrix`
+
+## Context references (mandatory)
+- Product SoT: `internal-docs/00_build/security-scanning-platform-spec.md`
+- Build gates: `internal-docs/00_build/build-day-decisions.md`
+- Adapter research: `internal-docs/00_build/research/scanner-output-adapters.md`
+- Demo lens: `internal-docs/01_demo_video/00-tripwire-demo-script.md`
+- Public pair: `docs/STATUS.md`, `docs/ARCHITECTURE.md`, `docs/research/adapters/scanner-output-adapters.md`, `docs/plan/*`
+- Non-SoT: do not use `internal-docs/02_prototypes/import-stash/` as truth
+
+## Spec (GWT / User Story)
+**Given** Horizon-A STATUS, slices 1–6 evidence, internal-docs SoT, and measured coverage (~47% Python; no Node gates)
+**When** the coverage audit runs
+**Then** `docs/plan/coverage-audit.md` lists each ship-path / Done-when / demo must-show capability as AT / unit / missing, records internal↔public parity deltas, and locks targets (ship-path ~95%; exclude guard/support.js)
+
+## Out of scope (already exists)
+- Re-running slice-5 gate-evidence backfill
+- Raising `fail_under` or adding Node coverage tools (slices 11–13)
+
+## Before-Checks [GATE]
+- [ ] Branch created (`slice/7-coverage-audit-matrix`)
+- [ ] Task file opened
+- [ ] Context pack opened (internal-docs 00_build + demo script + docs/STATUS)
+- [ ] Confirmed no prior `docs/plan/coverage-audit.md`
+
+## TDD Execution
+Docs-only. Matrix rows seeded from spec Done-when + build-day 3-lite + demo must-show + STATUS IMPLEMENTED.
+
+## After-Checks [GATE]
+- [ ] `docs/plan/coverage-audit.md` committed
+- [ ] Specification coverage: every matrix row has AT/unit/missing label
+- [ ] DECISIONS row for 95% / ship-path / Live E2E Won't-for-CI
+- [ ] Acceptance criteria met
+- [ ] Gate evidence `docs/plan/gate-evidence/slice-7.json` at PASS
+
+## Doc Audit (14-row checklist)
+| # | Item | Check |
+|-|------|-------|
+| 1–14 | Plan artifact + STATUS cross-links | N/A public README unless claims change |
+
+## Gate Status
+📋 PLANNED
+
+## Session Metrics
+| Metric | Value |
+|--------|-------|
+| Estimated Pomos | 1 (~25 min) |
+| Execution time | — |
+| Blockers encountered | — |
+| Next-session notes | Execute slice 8 after PASS |

--- a/docs/plan/slice-8-scanner-skill-parse-fixtures.md
+++ b/docs/plan/slice-8-scanner-skill-parse-fixtures.md
@@ -1,0 +1,54 @@
+# Slice 8: Scanner Skill Parse Fixtures (Delta)
+
+> Scenario: Brownfield | MoSCoW: Must
+
+## Slice Workflow Bundle
+- Slice name: slice-8-scanner-skill-parse-fixtures
+- Files: `sandbox/scanners.py`, `sandbox/test_*.py` (new or extend), fixture JSON under `fixtures/` or `sandbox/` test data
+- Exit criteria: Real `run_cisco_skill_scanner` / `_map_skill_findings` / `_safe_json` paths exercised via stubs for `_run`/`_which` only; no live CLI.
+- Commit pattern: `test(slice-8): cisco skill parse fixtures`
+
+## Branch
+`slice/8-scanner-skill-parse-fixtures`
+
+## Context references (mandatory)
+- Product SoT: `internal-docs/00_build/security-scanning-platform-spec.md` (Phase 2 adapters)
+- Adapter research: `internal-docs/00_build/research/scanner-output-adapters.md`
+- Public mirror: `docs/research/adapters/scanner-output-adapters.md`
+- Audit: `docs/plan/coverage-audit.md` (from slice 7)
+- Code: `sandbox/scanners.py`
+
+## Spec (GWT / User Story)
+**Given** recorded skill-scanner JSON (happy + malformed) and stubbed subprocess
+**When** skill adapter parse/map runs
+**Then** findings/status/console shapes match the adapter contract (research + current code); research drift flagged in DECISIONS or audit
+
+## Out of scope (already exists)
+- `test_scanners_status.py` `run_all` orchestration that **patches** `run_cisco_skill_scanner`
+- MCP live/behavioral cmd builders (`test_scanners_mcp_cli.py`)
+- Live CLI / Modal invocation
+
+## Before-Checks [GATE]
+- [ ] Branch created
+- [ ] Slice 7 ✅ or audit matrix available
+- [ ] Context pack + adapter research opened
+- [ ] Confirmed skill parse bodies still uncovered
+
+## TDD Execution
+Outside-in: failing fixture tests → GREEN with `_run`/`_which` stubs → refactor tests.
+VERIFY: `pytest sandbox/ -q --tb=short`
+
+## After-Checks [GATE]
+- [ ] Tests pass
+- [ ] Specification coverage: skill happy + malformed + map severity
+- [ ] Branch coverage on touched parse paths improved (toward slice 11)
+- [ ] Gate evidence `slice-8.json` at PASS
+
+## Gate Status
+📋 PLANNED
+
+## Session Metrics
+| Metric | Value |
+|--------|-------|
+| Estimated Pomos | 1 (~25 min) |
+| Next-session notes | Slice 9 in parallel-ok after 7; serial if shared fixtures |

--- a/docs/plan/slice-9-scanner-snyk-tessl-parse-fixtures.md
+++ b/docs/plan/slice-9-scanner-snyk-tessl-parse-fixtures.md
@@ -1,0 +1,51 @@
+# Slice 9: Snyk / Tessl Parse Fixtures (Delta)
+
+> Scenario: Brownfield | MoSCoW: Must
+
+## Slice Workflow Bundle
+- Slice name: slice-9-scanner-snyk-tessl-parse-fixtures
+- Files: `sandbox/scanners.py`, `sandbox/test_*.py`, fixture JSON
+- Exit criteria: Real `run_snyk` / `run_tessl` / `_collapse_severity` / `_tessl_quality_score` / `_snyk_cmd` paths via stubbed subprocess; characterization-safe.
+- Commit pattern: `test(slice-9): snyk tessl parse fixtures`
+
+## Branch
+`slice/9-scanner-snyk-tessl-parse-fixtures`
+
+## Context references (mandatory)
+- Product SoT: `internal-docs/00_build/security-scanning-platform-spec.md`
+- Adapter research: `internal-docs/00_build/research/scanner-output-adapters.md`
+- Public mirror: `docs/research/adapters/scanner-output-adapters.md`
+- Audit: `docs/plan/coverage-audit.md`
+- Code: `sandbox/scanners.py`
+
+## Spec (GWT / User Story)
+**Given** recorded Snyk and Tessl outputs (and edge/malformed cases)
+**When** adapters run with subprocess stubbed
+**Then** status rows, scores, and severity collapse match current behaviour; research mismatches logged
+
+## Out of scope (already exists)
+- Status tests that **patch** `run_snyk` / `run_tessl` for `run_all_scanners` overall_status
+- Live Snyk/Tessl CLI or Modal
+
+## Before-Checks [GATE]
+- [ ] Branch created
+- [ ] Slice 7 available
+- [ ] Adapter research opened
+- [ ] Confirmed Snyk/Tessl bodies still uncovered
+
+## TDD Execution
+Fixture-driven characterization → GREEN → refactor.
+VERIFY: `pytest sandbox/ -q --tb=short`
+
+## After-Checks [GATE]
+- [ ] Tests pass
+- [ ] Specification coverage: Snyk + Tessl + collapse edges
+- [ ] Gate evidence `slice-9.json` at PASS
+
+## Gate Status
+📋 PLANNED
+
+## Session Metrics
+| Metric | Value |
+|--------|-------|
+| Estimated Pomos | 1 (~25 min) |


### PR DESCRIPTION
## Summary
- docs(plan): add ship-path coverage slices 7–14 and sync status — DECIDED ~95% ship-path wave (delta-only stubs, internal-docs context pack); STATUS/CONTRIBUTING/docs index synced so CI floor 45% is not misread as 95%

## Test plan
- [x] Docs-only PR — no production code changes
- [x] Python: `pytest sandbox/` — 64 passed, coverage 47.2% (≥45% floor)
- [x] CLI: `cd cli && npm test` — 22/22 passed
- [x] Dashboard: `cd prototypes/dc-dashboard && npm test` — 38 passed, 1 skipped

## Test Results

| Stack | Result | Coverage |
|-------|--------|----------|
| Python (`sandbox` + `guard`) | 64 passed | 47.2% (fail_under 45) |
| CLI (`cli/`) | 22 passed | no gate (slice 12) |
| Dashboard Live ACL | 38 passed / 1 skipped | no gate (slice 13) |

## Notes
- Planning Path B Add via enhanced-flow-planner; execute starting at slice 7 after merge
- Slice 4 Remotion remains 🔴; Live Modal/Supabase CI Must remains Won't for this wave


Made with [Cursor](https://cursor.com)