### PR TITLE
docs(slice-07): put public trust strip first in coverage audit slice

### DIFF
--- a/docs/plan/DECISIONS.md
+++ b/docs/plan/DECISIONS.md
@@ -30,3 +30,4 @@
 | 2026-08-02 | planning | Added slices 7–14 | Path B Add via enhanced-flow-planner; delta-only vs existing suites; internal-docs context pack mandatory |
 | 2026-08-02 | health-check | Gap 2: Routing fingerprint | AUTO-FIXED on TRAIL Original Material |
 | 2026-08-02 | sync-docs | Coverage wave docs | STATUS DECIDED + CONTRIBUTING floors + docs/README plan links; README NO_CHANGE |
+| 2026-08-02 | urgency | Slice 7 Gate A = trust strip | Overmind/Ossprey badges + HTML/CI strings + Guard Future + Nightly non-gating + stale branch refs run first in slice 7 before coverage-audit.md; P1 pulled from deferred 14/16 |

--- a/docs/plan/PROGRESS.md
+++ b/docs/plan/PROGRESS.md
@@ -27,7 +27,7 @@
 | 4 | Sibling Remotion repo `claude-remotion-kickstart` (branch `video/tripwire`) not found on disk or under `neomatrix369` GitHub; no VO audio/transcript/render artifacts in `internal-docs/01_demo_video/` | 🔴 open — need path or clone URL |
 
 ## Forward Roadmap
-- Next execute: **slice 7** (coverage audit) on branch `plan/coverage-slices-7-14` then per-slice branches as needed.
+- Next execute: **slice 7** on `slice/7-coverage-audit-matrix` — Gate A trust strip (badges/Guard Future/Nightly honesty) then Gate B `coverage-audit.md`; then per-slice branches for 8+.
 - After coverage wave (7–14): ask whether to expand to **1+C** (product Phase 3 full + Guard/Reconciler as Should).
 - Won't for A: Drift demo, Phase 4/5, redesign, blast-radius, instruction→install→scan; Live E2E CI Must; support.js 95%.
 - Horizon A open: unblock slice 4 (VO/Remotion) for done=2b (independent of coverage wave).

--- a/docs/plan/slice-14-coverage-status-docs-sync.md
+++ b/docs/plan/slice-14-coverage-status-docs-sync.md
@@ -25,6 +25,9 @@
 ## Out of scope (already exists)
 - Slice 5 gate-evidence backfill for slices 1–6
 - Unblocking Remotion/slice 4
+- Overmind/Ossprey badge strip, Guard→Future in ARCHITECTURE, Nightly
+  mutmut/Chalk non-gating one-liner — owned by **slice 7** Gate A (regression-
+  check only here: grep still clean)
 
 ## Before-Checks [GATE]
 - [ ] Branch created
@@ -36,6 +39,7 @@ Docs-only.
 
 ## After-Checks [GATE]
 - [ ] STATUS/PROGRESS/DECISIONS updated
+- [ ] Regression: no Overmind/Ossprey public badges; Nightly non-gating still documented
 - [ ] Acceptance criteria met
 - [ ] Gate evidence `slice-14.json` at PASS
 

--- a/docs/plan/slice-7-coverage-audit-matrix.md
+++ b/docs/plan/slice-7-coverage-audit-matrix.md
@@ -4,9 +4,28 @@
 
 ## Slice Workflow Bundle
 - Slice name: slice-7-coverage-audit-matrix
-- Files: `docs/plan/coverage-audit.md`, `docs/plan/DECISIONS.md`, `docs/plan/TRAIL.md`
-- Exit criteria: `coverage-audit.md` exists with ship-path behavior matrix + internal-docs↔docs parity deltas + altitude notes; no CI floor raise in this slice.
-- Commit pattern: `docs(slice-7): coverage audit matrix and parity`
+- Files:
+  - Public badge/partner strip: `README.md`, `QUICKSTART.md`, `CONTRIBUTING.md`,
+    `SECURITY.md`, `docs/STATUS.md`, `docs/ARCHITECTURE.md`, `docs/README.md`,
+    `prototypes/README.md`, `fixtures/README.md`,
+    `prototypes/dc-dashboard/Tripwire.dc.html`,
+    `.github/workflows/ci.yml`, `.github/workflows/nightly.yml`,
+    `.github/dependabot.yml`
+  - Trust one-liners: `docs/ARCHITECTURE.md` (Guard → Future), `CONTRIBUTING.md`
+    (Nightly mutmut/Chalk non-gating)
+  - Plan refs: `docs/STATUS.md` DECIDED, `docs/plan/PROGRESS.md` Forward
+  - Matrix: `docs/plan/coverage-audit.md`, `docs/plan/DECISIONS.md`
+- Exit criteria:
+  1. Overmind/Ossprey absent from public badges/HTML footer/CI comments (grep clean;
+     TRAIL Forward Won't text may remain)
+  2. Guard not presented as current C4 L2 container (Future section)
+  3. CONTRIBUTING Nightly notes mutmut/Chalk as non-gating (`|| true`)
+  4. Stale `plan/coverage-slices-7-14` branch refs fixed (main / per-slice branches)
+  5. `coverage-audit.md` exists with ship-path behavior matrix + internal-docs↔docs
+     parity deltas + claim themes + altitude notes
+  6. No CI floor raise in this slice
+- Commit pattern: `docs(slice-7): trust strip + coverage audit matrix`
+  (split commits OK on same branch)
 
 ## Branch
 `slice/7-coverage-audit-matrix`
@@ -16,46 +35,76 @@
 - Build gates: `internal-docs/00_build/build-day-decisions.md`
 - Adapter research: `internal-docs/00_build/research/scanner-output-adapters.md`
 - Demo lens: `internal-docs/01_demo_video/00-tripwire-demo-script.md`
-- Public pair: `docs/STATUS.md`, `docs/ARCHITECTURE.md`, `docs/research/adapters/scanner-output-adapters.md`, `docs/plan/*`
+- Public pair: `docs/STATUS.md`, `docs/ARCHITECTURE.md`,
+  `docs/research/adapters/scanner-output-adapters.md`, `docs/plan/*`
 - Non-SoT: do not use `internal-docs/02_prototypes/import-stash/` as truth
 
 ## Spec (GWT / User Story)
-**Given** Horizon-A STATUS, slices 1–6 evidence, internal-docs SoT, and measured coverage (~47% Python; no Node gates)
+
+**Gate A — public trust (first)**
+**Given** Overmind/Ossprey badges and partner strings imply current capability, and
+Phase 5/Ossprey are Won't / unwired
+**When** slice 7 trust pass runs
+**Then** those badges/strings are removed; Guard is Future-only in ARCHITECTURE;
+Nightly non-gating is honest in CONTRIBUTING; STATUS/PROGRESS branch refs match main
+
+**Gate B — coverage audit matrix**
+**Given** Horizon-A STATUS, slices 1–6 evidence, internal-docs SoT, and measured
+coverage (~47% Python; no Node gates)
 **When** the coverage audit runs
-**Then** `docs/plan/coverage-audit.md` lists each ship-path / Done-when / demo must-show capability as AT / unit / missing, records internal↔public parity deltas, and locks targets (ship-path ~95%; exclude guard/support.js)
+**Then** `docs/plan/coverage-audit.md` lists each ship-path / Done-when / demo
+must-show capability as AT / unit / missing, records internal↔public parity deltas
+(incl. Realtime timing, demo Mock vs Live default, prototype vs ship for later
+slices), and locks targets (ship-path ~95%; exclude guard/support.js)
 
 ## Out of scope (already exists)
 - Re-running slice-5 gate-evidence backfill
 - Raising `fail_under` or adding Node coverage tools (slices 11–13)
+- Full Realtime/demo/prototype prose remediations (slice 16 — matrix only seeds rows)
+- Full claim-audit canvas + Live 3B (slice 15)
 
 ## Before-Checks [GATE]
 - [ ] Branch created (`slice/7-coverage-audit-matrix`)
 - [ ] Task file opened
 - [ ] Context pack opened (internal-docs 00_build + demo script + docs/STATUS)
 - [ ] Confirmed no prior `docs/plan/coverage-audit.md`
+- [ ] Inventory Overmind/Ossprey hits (markdown, HTML footer, workflow comments)
 
 ## TDD Execution
-Docs-only. Matrix rows seeded from spec Done-when + build-day 3-lite + demo must-show + STATUS IMPLEMENTED.
+Docs-only.
+1. **Trust strip first** — badges, HTML footer, CI comments, Guard Future, Nightly
+   honesty, branch-ref fixes; DECISIONS sync-docs row
+2. **Matrix** — seed from spec Done-when + build-day 3-lite + demo must-show +
+   STATUS IMPLEMENTED + nw-review claim themes
 
 ## After-Checks [GATE]
+- [ ] Grep: no public Overmind/Ossprey **badges** / HTML partner lines / CI comment
+      partner lists (TRAIL Forward Won't OK)
+- [ ] ARCHITECTURE: Guard only under Future (not current L2 container)
+- [ ] CONTRIBUTING: Nightly mutmut/Chalk marked non-gating
+- [ ] STATUS/PROGRESS: no stale `plan/coverage-slices-7-14` as current execute branch
 - [ ] `docs/plan/coverage-audit.md` committed
 - [ ] Specification coverage: every matrix row has AT/unit/missing label
-- [ ] DECISIONS row for 95% / ship-path / Live E2E Won't-for-CI
+- [ ] DECISIONS rows: sync-docs badge strip; 95% / ship-path / Live E2E Won't-for-CI
 - [ ] Acceptance criteria met
 - [ ] Gate evidence `docs/plan/gate-evidence/slice-7.json` at PASS
 
 ## Doc Audit (14-row checklist)
 | # | Item | Check |
 |-|------|-------|
-| 1–14 | Plan artifact + STATUS cross-links | N/A public README unless claims change |
+| 1 | README / public badges | Updated — Overmind/Ossprey removed |
+| 2 | ARCHITECTURE | Guard Future; badges removed |
+| 3 | CONTRIBUTING | Nightly honesty; badges removed |
+| 4 | STATUS / PROGRESS | Branch refs + badges |
+| 5–14 | Plan artifact + cross-links | coverage-audit.md ↔ TRAIL/PROGRESS |
 
 ## Gate Status
-📋 PLANNED
+📋 PLANNED — stub amended 2026-08-02 (trust strip = first gate)
 
 ## Session Metrics
 | Metric | Value |
 |--------|-------|
-| Estimated Pomos | 1 (~25 min) |
+| Estimated Pomos | 1–2 (~25–50 min) |
 | Execution time | — |
 | Blockers encountered | — |
-| Next-session notes | Execute slice 8 after PASS |
+| Next-session notes | Execute Gate A then B; then slice 8 |


### PR DESCRIPTION
## Summary
- docs(slice-07): put public trust strip first in coverage audit slice — Gate A (Overmind/Ossprey badges, Guard→Future, Nightly non-gating, stale branch refs) runs before Gate B `coverage-audit.md`; slice 14 notes ownership shift

## Test plan
From [slice-7-coverage-audit-matrix.md](docs/plan/slice-7-coverage-audit-matrix.md) (plan stub update only — Gate A/B not yet executed on public docs):
- [ ] Grep clean: no public Overmind/Ossprey badges / HTML partner lines / CI partner comments (after Gate A lands)
- [ ] ARCHITECTURE: Guard only under Future
- [ ] CONTRIBUTING: Nightly mutmut/Chalk marked non-gating
- [ ] STATUS/PROGRESS: no stale `plan/coverage-slices-7-14` as current execute branch
- [ ] `docs/plan/coverage-audit.md` exists after Gate B
- [x] Plan stubs + DECISIONS/PROGRESS updated on this PR

## Test Results
| Stack | Result | Notes |
|-------|--------|-------|
| Python (`pytest sandbox/`) | 64 passed | coverage 47.2% (floor 45%) |
| CLI (`cd cli && npm test`) | 22 passed | no coverage gate |
| Dashboard (`prototypes/dc-dashboard`) | 38 passed, 1 skipped | no coverage gate |


Made with [Cursor](https://cursor.com)