### PR TITLE
docs(slice-17): user-guide onboarding prerequisites and env procurement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # Tripwire credentials — mirror of security-scanning-platform-spec.md §5 Naming + §8.
 # Copy to .env locally if desired. NEVER commit real values.
+# Procure keys first: docs/user-guide/env-vars.md (SSOT for every key below).
+# Platform setup: docs/user-guide/prerequisites.md → supabase-setup → modal-setup → env-vars.
 # Omit any key you do not have — missing → that engine only (skipped_missing_credential).
 #
 # Naming: product CLI is `tripwire`. Scanner env *keys* stay upstream (Cisco / Snyk / Tessl).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,11 +2,16 @@
 
 ## Dev setup
 
-Follow [QUICKSTART.md](QUICKSTART.md) (Platform operator path) for `.env`, CLI
-link, `tripwire setup`, and Modal deploy. Short version:
+0. Tools + versions: [docs/user-guide/prerequisites.md](docs/user-guide/prerequisites.md)
+   (Node 22 / Python 3.12). Platform accounts:
+   [supabase-setup](docs/user-guide/supabase-setup.md) →
+   [modal-setup](docs/user-guide/modal-setup.md) →
+   [env-vars](docs/user-guide/env-vars.md) before copying `.env`.
 
-1. Copy `.env.example` → `.env` (Supabase + optional scanner keys —
-   `fixtures/OPTIONAL_SCANNER_KEYS.md`).
+Follow [QUICKSTART.md](QUICKSTART.md) (Platform operator path). Short version:
+
+1. Copy `.env.example` → `.env` using [env-vars.md](docs/user-guide/env-vars.md)
+   (`fixtures/OPTIONAL_SCANNER_KEYS.md` for Modal allowlist).
 2. `cd cli && npm install && npm link`
 3. `tripwire setup` (needs `SUPABASE_DB_URL`) and `./scripts/setup-modal.sh`
 4. Run checks below.

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -23,7 +23,8 @@ flowchart LR
 See the dashboard in about two minutes. No Supabase or Modal required if you use
 **Mock (demo data)**.
 
-**Prerequisites:** Git, Node.js
+**Prerequisites:** Git, **Node.js 22** (see `.nvmrc`). Tool matrix:
+[docs/user-guide/prerequisites.md](docs/user-guide/prerequisites.md).
 
 ```bash
 git clone https://github.com/neomatrix369/tripwire.git
@@ -31,6 +32,7 @@ cd tripwire
 node scripts/serve-dashboard.mjs
 # open http://127.0.0.1:8765/Tripwire.dc.html
 # Guard tab → data source → Mock (demo data)
+# Live is the UI default — you must select Mock for a no-cloud demo
 ```
 
 **Success:** Dashboard loads; status chip shows **Demo data** (or Live if you
@@ -43,8 +45,10 @@ More: [prototypes/README.md](prototypes/README.md)
 ## Scanner user
 
 Install the CLI and discover (or scan) a fixture without reading the whole repo.
+No Supabase or Modal accounts required for `--dry-discover`.
 
-**Prerequisites:** Git, Node.js, npm
+**Prerequisites:** Git, **Node.js 22**, npm —
+[docs/user-guide/prerequisites.md](docs/user-guide/prerequisites.md).
 
 ```bash
 cd cli && npm install && npm link
@@ -67,11 +71,17 @@ Fixtures: [fixtures/README.md](fixtures/README.md)
 
 Run the full stack: DB bootstrap, Modal sandbox, real scan, Live dashboard.
 
-**Prerequisites:** Node.js, Python + `modal`, Supabase project, Modal account
+**Prerequisites:** Node.js 22, Python 3.12 + `modal`, Supabase project, Modal
+account. Complete setup guides **before** copying `.env`:
+
+1. [docs/user-guide/prerequisites.md](docs/user-guide/prerequisites.md)
+2. [docs/user-guide/supabase-setup.md](docs/user-guide/supabase-setup.md)
+3. [docs/user-guide/modal-setup.md](docs/user-guide/modal-setup.md)
+4. [docs/user-guide/env-vars.md](docs/user-guide/env-vars.md) — every key + source
 
 ```bash
 cp .env.example .env
-# Set SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, SUPABASE_DB_URL (postgresql://)
+# Fill SUPABASE_* (and optional scanner keys) using env-vars.md
 # Prefer Session pooler URI if db.<ref>.supabase.co does not resolve
 # Optional Live browser: SUPABASE_ANON_KEY — or use serve-dashboard.mjs proxy
 
@@ -82,7 +92,7 @@ tripwire setup                 # apply DDL; or ./scripts/setup-supabase.sh
 pip install modal
 ./scripts/setup-modal.sh       # auth + secrets sync + deploy
 # Flags: --secrets-only | --deploy-only | --non-interactive | --env-file PATH
-# Keys: fixtures/OPTIONAL_SCANNER_KEYS.md
+# Keys: docs/user-guide/env-vars.md · fixtures/OPTIONAL_SCANNER_KEYS.md
 
 tripwire scan ./fixtures/skills/safe-csv-cleaner
 tripwire scan ./fixtures/mcp/mcp_manifest.json
@@ -94,8 +104,9 @@ node scripts/serve-dashboard.mjs
 **Success:** Scan creates rows in Supabase; dashboard Live chip shows items (or
 empty if no rows yet). Operator evidence notes: [docs/STATUS.md](docs/STATUS.md).
 
-Also: [.env.example](.env.example) ·
-[fixtures/OPTIONAL_SCANNER_KEYS.md](fixtures/OPTIONAL_SCANNER_KEYS.md)
+Also: [env-vars.md](docs/user-guide/env-vars.md) ·
+[.env.example](.env.example) ·
+[OPTIONAL_SCANNER_KEYS.md](fixtures/OPTIONAL_SCANNER_KEYS.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -24,12 +24,15 @@ watch findings. System shape: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 ## Run it
 
+Prerequisites first: [docs/user-guide/prerequisites.md](docs/user-guide/prerequisites.md).
+Secrets SSOT: [docs/user-guide/env-vars.md](docs/user-guide/env-vars.md).
+
 | Persona | Start here | What you will do |
 |---------|------------|------------------|
-| Demo in 2 min | [QUICKSTART → Demo](QUICKSTART.md#demo-viewer) | Open Mock dashboard, no cloud |
-| Scan skills/MCP | [QUICKSTART → Scanner](QUICKSTART.md#scanner-user) | `npm link` + `--dry-discover` |
-| Full platform | [QUICKSTART → Platform](QUICKSTART.md#platform-operator) | Supabase + Modal + Live scan |
-| Operate secrets | [.env.example](.env.example) | Fill keys — [OPTIONAL_SCANNER_KEYS](fixtures/OPTIONAL_SCANNER_KEYS.md) |
+| Demo in 2 min | [QUICKSTART → Demo](QUICKSTART.md#demo-viewer) | Node 22; select **Mock** (Live is default) |
+| Scan skills/MCP | [QUICKSTART → Scanner](QUICKSTART.md#scanner-user) | `npm link` + `--dry-discover` (no cloud) |
+| Full platform | [QUICKSTART → Platform](QUICKSTART.md#platform-operator) | Accounts → env-vars → Supabase + Modal + Live |
+| Operate secrets | [env-vars.md](docs/user-guide/env-vars.md) | Procure keys — [.env.example](.env.example) |
 | Compliance / audit | [prototypes/README.md](prototypes/README.md) | Mock UI + [fixtures](fixtures/README.md) |
 | Security reporter | [SECURITY.md](SECURITY.md) | Private disclosure path |
 
@@ -37,7 +40,7 @@ watch findings. System shape: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 ```bash
 node scripts/serve-dashboard.mjs
-# Guard tab → Mock (demo data)
+# Guard tab → data source → Mock (demo data) — Live is the default
 ```
 
 **Scanner user**
@@ -50,13 +53,14 @@ tripwire scan --dry-discover ./fixtures/skills/safe-csv-cleaner
 **Platform operator**
 
 ```bash
-cp .env.example .env   # SUPABASE_* + optional scanner keys
+# After prerequisites → supabase-setup → modal-setup → env-vars:
+cp .env.example .env
 cd cli && npm install && npm link && cd ..
 tripwire setup && ./scripts/setup-modal.sh
 tripwire scan ./fixtures/skills/safe-csv-cleaner
 ```
 
-Details for every path: [QUICKSTART.md](QUICKSTART.md).
+Details: [QUICKSTART.md](QUICKSTART.md).
 
 ## Contribute
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,14 +12,22 @@ Guides for **Tripwire**, by who you are and what you want to do.
 
 | Persona | Start here | Then |
 |---------|------------|------|
-| **Demo viewer** | [QUICKSTART → Demo](../QUICKSTART.md#demo-viewer) | [prototypes/README.md](../prototypes/README.md) |
-| **Scanner user** | [QUICKSTART → Scanner](../QUICKSTART.md#scanner-user) | [fixtures/README.md](../fixtures/README.md) |
-| **Platform operator** | [QUICKSTART → Platform](../QUICKSTART.md#platform-operator) | [.env.example](../.env.example) · [OPTIONAL_SCANNER_KEYS.md](../fixtures/OPTIONAL_SCANNER_KEYS.md) |
-| **Operate secrets / Modal** | [.env.example](../.env.example) | [OPTIONAL_SCANNER_KEYS.md](../fixtures/OPTIONAL_SCANNER_KEYS.md) |
+| **Demo viewer** | [user-guide/prerequisites](./user-guide/prerequisites.md) | [QUICKSTART → Demo](../QUICKSTART.md#demo-viewer) (select **Mock**) |
+| **Scanner user** | [user-guide/prerequisites](./user-guide/prerequisites.md) | [QUICKSTART → Scanner](../QUICKSTART.md#scanner-user) |
+| **Platform operator** | [prerequisites](./user-guide/prerequisites.md) → [supabase](./user-guide/supabase-setup.md) → [modal](./user-guide/modal-setup.md) → [env-vars](./user-guide/env-vars.md) | [QUICKSTART → Platform](../QUICKSTART.md#platform-operator) |
+| **Operate secrets / Modal** | [env-vars.md](./user-guide/env-vars.md) | [OPTIONAL_SCANNER_KEYS.md](../fixtures/OPTIONAL_SCANNER_KEYS.md) |
 | **Contributor** | [CONTRIBUTING.md](../CONTRIBUTING.md) | [ARCHITECTURE.md](./ARCHITECTURE.md) · [plan/PROGRESS.md](./plan/PROGRESS.md) |
 | **Compliance / audit** | [prototypes/README.md](../prototypes/README.md) | [fixtures/README.md](../fixtures/README.md) · [STATUS.md](./STATUS.md) |
 | **Security reporter** | [SECURITY.md](../SECURITY.md) | — |
 | **Agent / slice worker** | [AGENTS.md](../AGENTS.md) · [CLAUDE.md](../CLAUDE.md) | [plan/PROGRESS.md](./plan/PROGRESS.md) · [plan/TRAIL.md](./plan/TRAIL.md) |
+
+### Choose Your Path
+
+| Path | Cloud? | First docs |
+|------|--------|------------|
+| Demo | No | [prerequisites](./user-guide/prerequisites.md) → QUICKSTART Demo → select Mock |
+| Scanner | No | [prerequisites](./user-guide/prerequisites.md) → `--dry-discover` |
+| Platform | Yes | prerequisites → supabase-setup → modal-setup → env-vars → QUICKSTART Platform |
 
 ---
 
@@ -28,6 +36,8 @@ Guides for **Tripwire**, by who you are and what you want to do.
 | Doc | What it covers |
 |-----|----------------|
 | [QUICKSTART.md](../QUICKSTART.md) | Demo / scanner / platform paths |
+| [user-guide/prerequisites.md](./user-guide/prerequisites.md) | Persona × tool matrix; Node 22 / Python 3.12 |
+| [user-guide/env-vars.md](./user-guide/env-vars.md) | Procurement SSOT for `.env.example` keys |
 | [ARCHITECTURE.md](./ARCHITECTURE.md) | C4 L1–L2 diagrams, key flows, repo layout |
 | [STATUS.md](./STATUS.md) | RESEARCH / IMPLEMENTED / VERIFIED claims |
 | [CONTRIBUTING.md](../CONTRIBUTING.md) | Dev setup, hygiene gates, PR conventions |
@@ -41,11 +51,11 @@ Guides for **Tripwire**, by who you are and what you want to do.
 |-----|----------------|
 | [research/adapters/scanner-output-adapters.md](./research/adapters/scanner-output-adapters.md) | Scanner CLI output shapes (keep in sync with `sandbox/scanners.py`) |
 | [plan/README.md](./plan/README.md) | Wave folders `01-A-…` … `06-F-…` + tracker map |
-| [plan/PROGRESS.md](./plan/PROGRESS.md) | Slice groups A–F (execution order); next **D/17** → E coverage |
+| [plan/PROGRESS.md](./plan/PROGRESS.md) | Slice groups A–F (execution order); next **E/8** → 11–13 |
 | [plan/DECISIONS.md](./plan/DECISIONS.md) | Planning decisions (incl. ship-path ~95%; demo/hackathon closed) |
 | [plan/GATE_CONTRACT.md](./plan/GATE_CONTRACT.md) | Before/After close rule — ✅ only when all gates met |
 | [plan/TRAIL.md](./plan/TRAIL.md) | Execution trail + context pack (`internal-docs/00_build/`) |
-| [plan/04-D-operator-onboarding/](./plan/04-D-operator-onboarding/) | Next Must: wave D / slice 17 onboarding (then E coverage) |
+| [plan/04-D-operator-onboarding/](./plan/04-D-operator-onboarding/) | Wave D / slice 17 onboarding ✅ · next E coverage |
 
 ---
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -61,10 +61,9 @@ Reachable through production entry points / config:
 ## DECIDED (not yet IMPLEMENTED / VERIFIED)
 
 Ship-path coverage uplift (~95% instrumented on `cli/src`, `sandbox/`, Live ACL JS;
-omit `guard/` and `support.js`) — audit matrix ✅ (slice 7); floors still open
-(slices **8**, **11–13**). Operator onboarding docs (prereqs / env procurement) are
-**Must** next — wave **D** slice **17** — before coverage wave **E**. Path:
-**17 → 8 → 11 → 12 → 13**. Groups: [plan/PROGRESS.md](./plan/PROGRESS.md),
+omit `guard/` and `support.js`) — audit matrix ✅ (slice 7); operator onboarding ✅
+(slice 17 — `docs/user-guide/`). Floors still open (slices **8**, **11–13**). Path:
+**8 → 11 → 12 → 13**. Groups: [plan/PROGRESS.md](./plan/PROGRESS.md),
 [plan/DECISIONS.md](./plan/DECISIONS.md), [plan/GATE_CONTRACT.md](./plan/GATE_CONTRACT.md).
 
 Current CI Python floor remains **`fail_under=45`** (`pyproject.toml` / CI) with

--- a/docs/plan/04-D-operator-onboarding/slice-17-user-guide-onboarding.md
+++ b/docs/plan/04-D-operator-onboarding/slice-17-user-guide-onboarding.md
@@ -41,20 +41,20 @@
 **Platform** — Given no `.env`; When prerequisites → supabase-setup → modal-setup → env-vars → QUICKSTART Platform; Then required SUPABASE_* sources known, `tripwire setup` + `setup-modal.sh` + fixture scan toward Live.
 
 ## Before-Checks [GATE]
-- [ ] Branch `slice/17-user-guide-onboarding`
-- [ ] Phase 1 only (no Phase 2 creep)
-- [ ] `.env.example` key inventory for env-vars coverage
-- [ ] README baseline: 4 H2s, ≤100 lines
+- [x] Branch `slice/17-user-guide-onboarding`
+- [x] Phase 1 only (no Phase 2 creep)
+- [x] `.env.example` key inventory for env-vars coverage
+- [x] README baseline: 4 H2s, ≤100 lines
 
 ## After-Checks [GATE]
-- [ ] `docs/user-guide/{prerequisites,supabase-setup,modal-setup,env-vars}.md` all exist
-- [ ] Every key in `.env.example` has a row in `env-vars.md` (diff inventory in evidence)
-- [ ] QUICKSTART Platform section links setup guides before `cp .env.example`; Demo states Node 22 + select Mock
-- [ ] README Run-it → prereqs/env-vars; `docs/README.md` Choose Your Path; CONTRIBUTING step 0 + `wc -l` ≤80
-- [ ] README still exactly 4 H2s and ≤100 lines (`rg '^## ' README.md` + `wc -l`)
-- [ ] `rg -i 'overmind|ossprey' README.md QUICKSTART.md CONTRIBUTING.md` empty
-- [ ] PROGRESS/TRAIL critical path shows **17** → 8 → 11–13 (wave D→E; 7 ✅)
-- [ ] `docs/plan/gate-evidence/slice-17.json` `"verdict": "PASS"` + commands; ✅ only after merge
+- [x] `docs/user-guide/{prerequisites,supabase-setup,modal-setup,env-vars}.md` all exist
+- [x] Every key in `.env.example` has a row in `env-vars.md` (diff inventory in evidence)
+- [x] QUICKSTART Platform section links setup guides before `cp .env.example`; Demo states Node 22 + select Mock
+- [x] README Run-it → prereqs/env-vars; `docs/README.md` Choose Your Path; CONTRIBUTING step 0 + `wc -l` ≤80
+- [x] README still exactly 4 H2s and ≤100 lines (`rg '^## ' README.md` + `wc -l`)
+- [x] `rg -i 'overmind|ossprey' README.md QUICKSTART.md CONTRIBUTING.md` empty
+- [x] PROGRESS/TRAIL critical path shows **8** → 11–13 (wave E; 17 ✅)
+- [x] `docs/plan/gate-evidence/slice-17.json` `"verdict": "PASS"` + commands; ✅ only after merge
 
 ## Doc Audit
 | # | Check |
@@ -75,7 +75,7 @@
 - Templates: `.env.example`, `fixtures/OPTIONAL_SCANNER_KEYS.md`
 
 ## Gate Status
-📋 PLANNED
+✅ PASSED
 
 ## Session Metrics
 | Metric | Value |

--- a/docs/plan/DECISIONS.md
+++ b/docs/plan/DECISIONS.md
@@ -42,5 +42,6 @@
 | 2026-08-02 | slice-7 | ✅ PASSED | After-Checks re-verified on `main` post PRs #26/#27; `gate-evidence/slice-7.json` → PASS. Next Must: **17**. |
 | 2026-08-02 | slice-groups | Execution-wave grouping | TRAIL/PROGRESS group A→F by run order: A Live/GWT → B char+sync → C audit → D onboarding(17) → E coverage → F claims. Not numeric slice order. |
 | 2026-08-02 | slice-layout | Group folders under docs/plan/ | Slices live in `01-A-…` … `06-F-…` by execution wave; trackers link into folders. |
-| 2026-08-02 | naming | Wave F rename | **Claim honesty** → **Claim audit**; folder `06-F-claim-audit/`. |
 | 2026-08-02 | refs | Path sync after layout | Trackers, STATUS, docs index, coverage-audit, gate-evidence `spec_path`, plan README, Cursor onboarding plan → wave folders. No `docs/plan/slice-N-*.md` at plan root. |
+| 2026-08-02 | slice-17 | ✅ PASSED (docs-only) | Phase 1 user-guide (prereqs/supabase/modal/env-vars) + QUICKSTART/README/docs index/CONTRIBUTING wire. Review: docs-only exception (GATE_CONTRACT). Next Must: **8**. |
+| 2026-08-02 | slice-17 | docs-only review skip | No `/nw-review` — documentation-only slice; GATE_CONTRACT exception recorded here. |

--- a/docs/plan/PROGRESS.md
+++ b/docs/plan/PROGRESS.md
@@ -8,21 +8,20 @@
 | 1 | [`01-A-…`](01-A-live-path-gwt/) | **A — Live path + GWT** | 1 → 2 → 3 · 4 | ✅ · 4 📦 |
 | 2 | [`02-B-…`](02-B-characterization-evidence/) | **B — Characterization + evidence sync** | 6 → 5 | ✅ |
 | 3 | [`03-C-…`](03-C-trust-coverage-audit/) | **C — Trust + coverage audit** | 7 | ✅ |
-| 4 | [`04-D-…`](04-D-operator-onboarding/) | **D — Operator onboarding** | **17** | 📋 **next** |
-| 5 | [`05-E-…`](05-E-ship-path-coverage/) | **E — Ship-path coverage** | 8 → (9∥10) → 11 → 12 → 13 → 14 | 📋 |
+| 4 | [`04-D-…`](04-D-operator-onboarding/) | **D — Operator onboarding** | **17** | ✅ |
+| 5 | [`05-E-…`](05-E-ship-path-coverage/) | **E — Ship-path coverage** | 8 → (9∥10) → 11 → 12 → 13 → 14 | 📋 **next** |
 | 6 | [`06-F-…`](06-F-claim-audit/) | **F — Claim audit** | 15 · 16 | 📋 · 16 📦 |
 
-**Open critical path (within D→E):** `17 → 8 → 11 → 12 → 13`
+**Open critical path (within E):** `8 → 11 → 12 → 13`
 
 ## Execution order (open work)
 
 | Order | Wave | # | Slice | MoSCoW | Status |
 |------:|-----:|---|-------|--------|--------|
-| 1 | D | **17** | [user-guide-onboarding](04-D-operator-onboarding/slice-17-user-guide-onboarding.md) | Must | 📋 **Next** |
-| 2 | E | 8 | [scanner-skill-parse-fixtures](05-E-ship-path-coverage/slice-8-scanner-skill-parse-fixtures.md) | Must | 📋 |
-| 3 | E | 11 | [python-ship-path-coverage-95](05-E-ship-path-coverage/slice-11-python-ship-path-coverage-95.md) | Must | 📋 |
-| 4 | E | 12 | [cli-coverage-gate-95](05-E-ship-path-coverage/slice-12-cli-coverage-gate-95.md) | Must | 📋 |
-| 5 | E | 13 | [live-acl-coverage-gate-95](05-E-ship-path-coverage/slice-13-live-acl-coverage-gate-95.md) | Must | 📋 |
+| 1 | E | 8 | [scanner-skill-parse-fixtures](05-E-ship-path-coverage/slice-8-scanner-skill-parse-fixtures.md) | Must | 📋 **Next** |
+| 2 | E | 11 | [python-ship-path-coverage-95](05-E-ship-path-coverage/slice-11-python-ship-path-coverage-95.md) | Must | 📋 |
+| 3 | E | 12 | [cli-coverage-gate-95](05-E-ship-path-coverage/slice-12-cli-coverage-gate-95.md) | Must | 📋 |
+| 4 | E | 13 | [live-acl-coverage-gate-95](05-E-ship-path-coverage/slice-13-live-acl-coverage-gate-95.md) | Must | 📋 |
 | — | E | 9 → 10 → 14 | Should coverage deltas / STATUS sync | Should | 📋 |
 | — | F | 15 | claim audit (16 📦) | Should | 📋 |
 
@@ -50,7 +49,7 @@
 ### D — Operator onboarding
 | # | Slice | MoSCoW | Status | Started | Completed | Est. time |
 |---|-------|--------|--------|---------|-----------|-----------|
-| **17** | [slice-17-user-guide-onboarding](04-D-operator-onboarding/slice-17-user-guide-onboarding.md) | Must | 📋 | — | — | ~50 min |
+| **17** | [slice-17-user-guide-onboarding](04-D-operator-onboarding/slice-17-user-guide-onboarding.md) | Must | ✅ | 2026-08-02 | 2026-08-02 | ~50 min |
 
 ### E — Ship-path coverage
 | # | Slice | MoSCoW | Status | Started | Completed | Est. time |
@@ -80,10 +79,10 @@
 | 4 (historical) | Remotion sibling + VO assets missing | 📦 closed with demo/hackathon deferral — reinstate slice 4 if film day returns |
 
 ## Forward Roadmap
-- Waves **A–C** done. Next: **D (17)** → **E** Musts 8 → 11–13 → **F (15)** as Should
+- Waves **A–D** done. Next: **E** Musts 8 → 11–13 → **F (15)** as Should
 - E Should (9, 10, 14) beside or after Must coverage
 - **Deferred / Won't (A):** 4 (in A), 16 (in F) — reinstate only if a new demo need arises
-- Slice 17 = RPF-style prereqs/env procurement; Phase 2 guides = later slice (18+)
+- Slice 17 ✅ = RPF-style prereqs/env procurement; Phase 2 guides = later slice (18+)
 - Gate close: [GATE_CONTRACT.md](GATE_CONTRACT.md)
 - After E Musts: ask 1+C vs continue F claim audit
 - Won't for A: Drift, Phase 4/5, redesign, blast-radius, instruction→install→scan; Live E2E CI Must; support.js 95%; demo video / hackathon film day
@@ -109,5 +108,6 @@
 | 2026-08-02 | slice/7-coverage-audit-matrix | slice-workflow | 7 | ✅ PASSED (#26/#27) | Wave C — trust strip + audit |
 | 2026-08-02 | main / plan | enhanced-flow-planner Add | 15–16 | 📋/📦 | Wave F; 16 deferred with demo close |
 | 2026-08-02 | main / plan | docs onboarding | 17 | 📋 | Wave D — next Must |
+| 2026-08-02 | slice/17-user-guide-onboarding | slice-workflow | 17 | ✅ PASSED | Wave D — user-guide Phase 1 |
 | 2026-08-02 | main / plan | GATE_CONTRACT | all | 📋 policy | Hard close rule |
 | 2026-08-02 | docs/gate-contract-onboarding-priority | sync-docs + clean-commit | 7, plan | pushed | Groups + close slice 7 on trackers |

--- a/docs/plan/README.md
+++ b/docs/plan/README.md
@@ -7,8 +7,8 @@ Horizon A trackers and slice stubs. **Slice files live in wave folders** (execut
 | 1 | [01-A-live-path-gwt/](01-A-live-path-gwt/) | Live path + GWT (1–4) |
 | 2 | [02-B-characterization-evidence/](02-B-characterization-evidence/) | Characterization + evidence (6, 5) |
 | 3 | [03-C-trust-coverage-audit/](03-C-trust-coverage-audit/) | Trust + coverage audit (7) |
-| 4 | [04-D-operator-onboarding/](04-D-operator-onboarding/) | Operator onboarding (17) — **next** |
-| 5 | [05-E-ship-path-coverage/](05-E-ship-path-coverage/) | Ship-path coverage (8–14) |
+| 4 | [04-D-operator-onboarding/](04-D-operator-onboarding/) | Operator onboarding (17) — ✅ |
+| 5 | [05-E-ship-path-coverage/](05-E-ship-path-coverage/) | Ship-path coverage (8–14) — **next** |
 | 6 | [06-F-claim-audit/](06-F-claim-audit/) | Claim audit (15–16) |
 
 | Tracker | Role |

--- a/docs/plan/TRAIL.md
+++ b/docs/plan/TRAIL.md
@@ -83,8 +83,8 @@ Groups are ordered by when the wave ran (or will run), not by slice number.
 | 1 | [`01-A-live-path-gwt/`](01-A-live-path-gwt/) | **A — Live path + GWT** | 1 → 2 → 3 (4 attempted) | A done; 4 📦 |
 | 2 | [`02-B-characterization-evidence/`](02-B-characterization-evidence/) | **B — Characterization + evidence sync** | 6 → 5 | ✅ |
 | 3 | [`03-C-trust-coverage-audit/`](03-C-trust-coverage-audit/) | **C — Trust + coverage audit** | 7 | ✅ |
-| 4 | [`04-D-operator-onboarding/`](04-D-operator-onboarding/) | **D — Operator onboarding** | **17** | 📋 **next** |
-| 5 | [`05-E-ship-path-coverage/`](05-E-ship-path-coverage/) | **E — Ship-path coverage** | 8 → (9∥10) → 11 → 12 → 13 → 14 | 📋 |
+| 4 | [`04-D-operator-onboarding/`](04-D-operator-onboarding/) | **D — Operator onboarding** | **17** | ✅ |
+| 5 | [`05-E-ship-path-coverage/`](05-E-ship-path-coverage/) | **E — Ship-path coverage** | 8 → (9∥10) → 11 → 12 → 13 → 14 | 📋 **next** |
 | 6 | [`06-F-claim-audit/`](06-F-claim-audit/) | **F — Claim audit** | 15 (16 deferred) | 📋 / 📦 |
 
 **Status legend**: `📋 PLANNED · 🔨 IN PROGRESS · ✅ PASSED · 🔀 ON BRANCH · 🔴 BLOCKED · 📦 DEFERRED`
@@ -111,13 +111,13 @@ Groups are ordered by when the wave ran (or will run), not by slice number.
 |---|------|------|--------|--------|------------|-------|-----------|
 | 7 | [slice-7-coverage-audit-matrix](03-C-trust-coverage-audit/slice-7-coverage-audit-matrix.md) | Coverage Audit Matrix + Docs Parity | Must | ✅ | none | #26/#27 | ~4 min |
 
-### D — Operator onboarding (next)
+### D — Operator onboarding (executed 2026-08-02)
 
 | # | File | Name | MoSCoW | Status | Depends on | Issue | Read time |
 |---|------|------|--------|--------|------------|-------|-----------|
-| **17** | [slice-17-user-guide-onboarding](04-D-operator-onboarding/slice-17-user-guide-onboarding.md) | User-Guide Onboarding (Prereqs + Env) | Must | 📋 | 7 | — | ~5 min |
+| **17** | [slice-17-user-guide-onboarding](04-D-operator-onboarding/slice-17-user-guide-onboarding.md) | User-Guide Onboarding (Prereqs + Env) | Must | ✅ | 7 | — | ~5 min |
 
-### E — Ship-path coverage (after D)
+### E — Ship-path coverage (next)
 
 | # | File | Name | MoSCoW | Status | Depends on | Issue | Read time |
 |---|------|------|--------|--------|------------|-------|-----------|
@@ -154,10 +154,9 @@ Groups are ordered by when the wave ran (or will run), not by slice number.
 
 ## Execute priority (by wave — 2026-08-02)
 
-1. Waves **A–C** ✅ — Live/GWT, characterization/evidence, trust+audit
-2. Wave **D** Must: **17** (onboarding) — **next**
-3. Wave **E** Must: 8 → 11 → 12 → 13 · Should: 9 → 10 → 14
-4. Wave **F** Should: 15 · 16 📦 (demo remediations deferred with 4)
+1. Waves **A–D** ✅ — Live/GWT, characterization/evidence, trust+audit, onboarding
+2. Wave **E** Must: 8 → 11 → 12 → 13 — **next** · Should: 9 → 10 → 14
+3. Wave **F** Should: 15 · 16 📦 (demo remediations deferred with 4)
 
 See also PROGRESS.md **Slice groups** and [GATE_CONTRACT.md](GATE_CONTRACT.md).
 

--- a/docs/plan/gate-evidence/slice-17.json
+++ b/docs/plan/gate-evidence/slice-17.json
@@ -1,0 +1,59 @@
+{
+  "slice": 17,
+  "date": "2026-08-02",
+  "branch": "slice/17-user-guide-onboarding",
+  "verdict": "PASS",
+  "before_checks": "all green",
+  "after_checks": [
+    "user-guide files exist",
+    "env-vars rows cover .env.example keys",
+    "QUICKSTART Platform links setup before cp .env; Demo Node 22 + Mock",
+    "README Run-it → prereqs/env-vars; docs/README Choose Your Path; CONTRIBUTING step 0 ≤80",
+    "README 4 H2s ≤100 lines",
+    "no Overmind/Ossprey in README/QUICKSTART/CONTRIBUTING",
+    "PROGRESS/TRAIL critical path 8 → 11–13",
+    "gate-evidence PASS"
+  ],
+  "env_key_inventory": [
+    "SUPABASE_ANON_KEY",
+    "SUPABASE_URL",
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "SUPABASE_DB_URL",
+    "SNYK_TOKEN",
+    "SKILL_SCANNER_LLM_API_KEY",
+    "SKILL_SCANNER_LLM_MODEL",
+    "SKILL_SCANNER_LLM_PROVIDER",
+    "SKILL_SCANNER_LLM_BASE_URL",
+    "MCP_SCANNER_LLM_API_KEY",
+    "MCP_SCANNER_LLM_MODEL",
+    "MCP_SCANNER_LLM_BASE_URL",
+    "TESSL_TOKEN",
+    "AI_DEFENSE_API_KEY",
+    "MCP_SCANNER_API_KEY",
+    "MCP_SCANNER_ENDPOINT",
+    "VIRUSTOTAL_API_KEY",
+    "MODAL_TOKEN_ID (commented)",
+    "MODAL_TOKEN_SECRET (commented)",
+    "SKILL_SCANNER_LLM_API_VERSION (commented)",
+    "MCP_SCANNER_LLM_API_VERSION (commented)",
+    "TESSL_WORKSPACE (commented)",
+    "AI_DEFENSE_API_URL (commented)"
+  ],
+  "commands": [
+    {
+      "cmd": "ls docs/user-guide/{prerequisites,supabase-setup,modal-setup,env-vars}.md",
+      "result": "all four exist"
+    },
+    {
+      "cmd": "rg '^## ' README.md; wc -l README.md CONTRIBUTING.md",
+      "result": "4 H2s; README 77; CONTRIBUTING 71"
+    },
+    {
+      "cmd": "rg -i 'overmind|ossprey' README.md QUICKSTART.md CONTRIBUTING.md",
+      "result": "empty"
+    }
+  ],
+  "review": "docs-only DECISIONS 2026-08-02",
+  "pr": null,
+  "spec_path": "docs/plan/04-D-operator-onboarding/slice-17-user-guide-onboarding.md"
+}

--- a/docs/user-guide/env-vars.md
+++ b/docs/user-guide/env-vars.md
@@ -1,0 +1,59 @@
+# Environment variables
+
+> Procurement SSOT for every key in [`.env.example`](../../.env.example).
+> Platform: procure accounts ([supabase-setup](./supabase-setup.md), [modal-setup](./modal-setup.md)) **before** `cp .env.example .env`.
+> Omit any key you do not have — missing → that engine only (`skipped_missing_credential`).
+
+Companion allowlist: [OPTIONAL_SCANNER_KEYS.md](../../fixtures/OPTIONAL_SCANNER_KEYS.md).
+
+## Platform plumbing
+
+| Key | Required for | Where to get it |
+|-----|--------------|-----------------|
+| `SUPABASE_URL` | Platform / Live / Modal HTTP | Supabase → Project Settings → API → Project URL |
+| `SUPABASE_ANON_KEY` | Live browser (optional) | Supabase → API → `anon` `public`. Or skip and use `serve-dashboard.mjs` proxy |
+| `SUPABASE_SERVICE_ROLE_KEY` | Platform writes + Modal | Supabase → API → `service_role` (server only) |
+| `SUPABASE_DB_URL` | `tripwire setup` DDL | Supabase → Database → connection string (`postgresql://…`). Prefer Session pooler if Direct DNS fails |
+| `MODAL_TOKEN_ID` | Optional non-interactive Modal | Modal → Settings → Tokens (prefer `modal setup` login) |
+| `MODAL_TOKEN_SECRET` | Optional non-interactive Modal | Same as above |
+
+## Tier B — Semantic (recommended MVP)
+
+| Key | Required for | Where to get it |
+|-----|--------------|-----------------|
+| `SNYK_TOKEN` | Snyk skill/MCP depth | [Snyk](https://snyk.io) account → API token |
+| `SKILL_SCANNER_LLM_API_KEY` | Cisco Skill Scanner `--use-llm` | Your LLM provider API key (must match MODEL) |
+| `SKILL_SCANNER_LLM_MODEL` | Skill LLM routing | e.g. `anthropic/claude-sonnet-4-20250514` or `openai/gpt-4o` |
+| `SKILL_SCANNER_LLM_PROVIDER` | Custom / OpenAI-compatible | Optional; e.g. `openai` for custom BASE_URL |
+| `SKILL_SCANNER_LLM_BASE_URL` | Custom LLM endpoint | Optional provider base URL |
+| `SKILL_SCANNER_LLM_API_VERSION` | Azure-style APIs | Optional; commented in `.env.example` |
+| `MCP_SCANNER_LLM_API_KEY` | Cisco MCP Scanner `behavioral` | LLM key (hard-errors if subcommand enabled without it) |
+| `MCP_SCANNER_LLM_MODEL` | MCP LLM routing | e.g. `gpt-4o` / `openai/gpt-4o` |
+| `MCP_SCANNER_LLM_BASE_URL` | Custom MCP LLM endpoint | Optional |
+| `MCP_SCANNER_LLM_API_VERSION` | Azure-style APIs | Optional; commented in `.env.example` |
+| `TESSL_TOKEN` | Tessl on Modal/CI | After `tessl login`, `tessl api-key create --workspace <name>`. Local smoke can use browser SSO only |
+| `TESSL_WORKSPACE` | Tessl workspace name | Optional; scanners default to `default` |
+
+## Tier C — Full depth (paid Cisco AI Defense)
+
+| Key | Required for | Where to get it |
+|-----|--------------|-----------------|
+| `AI_DEFENSE_API_KEY` | Skill Scanner `--use-aidefense` | Security Cloud Control → AI Defense UI (`X-Cisco-AI-Defense-API-Key`) |
+| `AI_DEFENSE_API_URL` | Custom AI Defense API host | Optional override; commented in `.env.example` |
+| `MCP_SCANNER_API_KEY` | MCP Scanner cloud inspect | Same AI Defense UI |
+| `MCP_SCANNER_ENDPOINT` | MCP inspect API base | Default in `.env.example`: US Cisco inspect endpoint |
+
+## Optional (any tier)
+
+| Key | Required for | Where to get it |
+|-----|--------------|-----------------|
+| `VIRUSTOTAL_API_KEY` | Binary hash checks | [VirusTotal](https://www.virustotal.com) API key; omit freely |
+
+## Wire into Modal
+
+```bash
+./scripts/setup-modal.sh
+# or secrets only: ./scripts/setup-modal.sh --secrets-only
+```
+
+See [modal-setup.md](./modal-setup.md). Manual CLI fallback is documented in [OPTIONAL_SCANNER_KEYS.md](../../fixtures/OPTIONAL_SCANNER_KEYS.md).

--- a/docs/user-guide/modal-setup.md
+++ b/docs/user-guide/modal-setup.md
@@ -1,0 +1,52 @@
+# Modal setup
+
+> Platform operators only. Complete [supabase-setup](./supabase-setup.md) and fill platform keys in `.env` first.
+
+## 1. Account + CLI
+
+1. Create an account at [modal.com](https://modal.com).
+2. Install and authenticate:
+
+```bash
+pip install modal
+modal setup
+# Prefer interactive login. Tokens (MODAL_TOKEN_ID / MODAL_TOKEN_SECRET) are optional.
+```
+
+## 2. One-shot sync + deploy
+
+From repo root, with a filled `.env`:
+
+```bash
+./scripts/setup-modal.sh
+```
+
+What it does:
+
+1. Reads allowlisted non-empty keys from `.env` (never prints values).
+2. Syncs Modal secrets `tripwire-supabase` + `tripwire-scan-secrets` (`--force`).
+3. Deploys `sandbox/scan_app.py`.
+
+Useful flags:
+
+| Flag | Effect |
+|------|--------|
+| `--secrets-only` | Sync secrets; skip deploy |
+| `--deploy-only` | Deploy only (auth still checked) |
+| `--non-interactive` | Fail if not authenticated and tokens unset |
+| `--env-file PATH` | Use a non-default env file |
+
+Allowlist detail: [OPTIONAL_SCANNER_KEYS.md](../../fixtures/OPTIONAL_SCANNER_KEYS.md).
+
+## 3. Verify
+
+```bash
+modal app list
+# Expect tripwire-scan (or your deployed app name) after a successful deploy
+```
+
+Then run a fixture scan and Live dashboard per [QUICKSTART → Platform](../../QUICKSTART.md#platform-operator).
+
+## Next
+
+→ [env-vars.md](./env-vars.md) (procurement SSOT) · back to [prerequisites](./prerequisites.md)

--- a/docs/user-guide/prerequisites.md
+++ b/docs/user-guide/prerequisites.md
@@ -1,0 +1,38 @@
+# Prerequisites
+
+> Tools and accounts by persona. Verify versions before copying `.env`.
+
+Pins: Node **22** (`.nvmrc`) · Python **3.12** (`.python-version`).
+
+## Choose your path
+
+| Persona | Tools | Cloud accounts | Next |
+|---------|-------|----------------|------|
+| **Demo viewer** | Git, Node 22 | None | [QUICKSTART → Demo](../../QUICKSTART.md#demo-viewer) — select **Mock** |
+| **Scanner user** | Git, Node 22, npm | None | [QUICKSTART → Scanner](../../QUICKSTART.md#scanner-user) |
+| **Platform operator** | Git, Node 22, npm, Python 3.12, `modal` CLI | Supabase + Modal | [supabase-setup](./supabase-setup.md) → [modal-setup](./modal-setup.md) → [env-vars](./env-vars.md) |
+
+Demo and Scanner need **no** Supabase or Modal. Platform: procure accounts and keys **before** `cp .env.example .env`.
+
+## Verify versions
+
+```bash
+node -v    # v22.x (nvm use / fnm use if needed)
+python3 -V # Python 3.12.x
+git --version
+```
+
+Optional (Platform only):
+
+```bash
+pip install modal
+modal --version
+```
+
+## What each persona does
+
+- **Demo** — open the dashboard with Mock data. Live is the UI default; you must switch to **Mock (demo data)** on the Guard tab.
+- **Scanner** — `tripwire scan --dry-discover` on a fixture. No Modal spawn.
+- **Platform** — apply schema, sync Modal secrets, run a real scan, view Live dashboard.
+
+Secrets SSOT: [env-vars.md](./env-vars.md). Allowlist notes: [OPTIONAL_SCANNER_KEYS.md](../../fixtures/OPTIONAL_SCANNER_KEYS.md).

--- a/docs/user-guide/supabase-setup.md
+++ b/docs/user-guide/supabase-setup.md
@@ -1,0 +1,50 @@
+# Supabase setup
+
+> Platform operators only. Do this **before** `cp .env.example .env`.
+
+## 1. Create a project
+
+1. Sign in at [supabase.com](https://supabase.com).
+2. Create a project; wait until it is healthy (not paused).
+3. Open **Project Settings → API**.
+
+## 2. Copy API values
+
+| Key | Where in Supabase UI | Used for |
+|-----|----------------------|----------|
+| `SUPABASE_URL` | Project Settings → API → Project URL (`https://<ref>.supabase.co`) | HTTP clients (CLI probe, Modal, Live dashboard) |
+| `SUPABASE_ANON_KEY` | Project Settings → API → `anon` `public` | Browser Live mode (RLS reads) or omit and use `serve-dashboard.mjs` proxy |
+| `SUPABASE_SERVICE_ROLE_KEY` | Project Settings → API → `service_role` | Server writes; Modal secret `tripwire-supabase` |
+
+Never put `service_role` in browser-facing config. Prefer `node scripts/serve-dashboard.mjs` (local proxy) if you skip the anon key.
+
+## 3. Database URL (DDL)
+
+`SUPABASE_DB_URL` is a `postgresql://…` URI for `tripwire setup` / first-scan DDL. It is **not** the HTTP API URL.
+
+1. Open **Project Settings → Database**.
+2. Prefer **Session pooler** if Direct `db.<ref>.supabase.co` fails DNS (`ENOTFOUND`).
+3. Formats (fill password / ref / region):
+
+```text
+# Direct
+postgresql://postgres:...@db.<ref>.supabase.co:5432/postgres
+
+# Session pooler
+postgresql://postgres.<ref>:...@aws-0-<region>.pooler.supabase.com:5432/postgres
+```
+
+## 4. Apply schema
+
+After keys are in `.env` (see [env-vars.md](./env-vars.md)):
+
+```bash
+cd cli && npm install && npm link && cd ..
+tripwire setup
+# or: ./scripts/setup-supabase.sh
+# After schema pulls: tripwire setup --force
+```
+
+## Next
+
+→ [modal-setup.md](./modal-setup.md) · full run: [QUICKSTART → Platform](../../QUICKSTART.md#platform-operator)


### PR DESCRIPTION
## Summary
- Add Phase 1 `docs/user-guide/` (prerequisites, supabase-setup, modal-setup, env-vars)
- Wire QUICKSTART/README/docs index/CONTRIBUTING so Platform procures accounts before `.env`
- Close wave D slice 17; critical path advances to E Musts 8 → 11–13

## Test plan
- [x] `ls docs/user-guide/{prerequisites,supabase-setup,modal-setup,env-vars}.md`
- [x] README 4 H2s, ≤100 lines; CONTRIBUTING ≤80
- [x] `rg -i 'overmind|ossprey' README.md QUICKSTART.md CONTRIBUTING.md` empty
- [x] Every `.env.example` key has a row in `env-vars.md`


Made with [Cursor](https://cursor.com)