### PR TITLE
docs(slice-17): clarify Live setup and operator readiness

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,14 @@ This is the contributor path for people who use Tripwire and also develop, test,
 or share improvements. Complete the shared [QUICKSTART.md](QUICKSTART.md) flow
 before following these development instructions.
 
+[![Cursor](https://img.shields.io/badge/Cursor-000000?style=flat)](https://cursor.com)
+[![Modal](https://img.shields.io/badge/Modal-7C5CFF?style=flat)](https://modal.com)
+[![Supabase](https://img.shields.io/badge/Supabase-3ECF8E?style=flat&logo=supabase&logoColor=white)](https://supabase.com)
+[![Tripwire](https://img.shields.io/badge/Tripwire-1a1a2e?style=flat)](https://github.com/neomatrix369/tripwire)
+[![Cisco](https://img.shields.io/badge/Cisco-1BA0D7?style=flat)](https://developer.cisco.com)
+[![Snyk](https://img.shields.io/badge/Snyk-4C4A73?style=flat&logo=snyk&logoColor=white)](https://snyk.io)
+[![Tessl](https://img.shields.io/badge/Tessl-111111?style=flat)](https://tessl.io)
+
 ## Dev setup
 
 0. Tools + versions: [docs/user-guide/prerequisites.md](docs/user-guide/prerequisites.md)
@@ -68,13 +76,3 @@ are excluded from secrets scanners.
 - [CI](https://github.com/neomatrix369/tripwire/actions/workflows/ci.yml) (`.github/workflows/ci.yml`) — secrets scanning, SAST, Trivy, ruff/bandit, CLI tests
 - [Nightly](https://github.com/neomatrix369/tripwire/actions/workflows/nightly.yml) (`.github/workflows/nightly.yml`) — T4 deep checks
 - Workflow map: [docs/README.md § CI workflows](docs/README.md#ci-workflows)
-
----
-
-[![Cursor](https://img.shields.io/badge/Cursor-000000?style=flat)](https://cursor.com)
-[![Modal](https://img.shields.io/badge/Modal-7C5CFF?style=flat)](https://modal.com)
-[![Supabase](https://img.shields.io/badge/Supabase-3ECF8E?style=flat&logo=supabase&logoColor=white)](https://supabase.com)
-[![Tripwire](https://img.shields.io/badge/Tripwire-1a1a2e?style=flat)](https://github.com/neomatrix369/tripwire)
-[![Cisco](https://img.shields.io/badge/Cisco-1BA0D7?style=flat)](https://developer.cisco.com)
-[![Snyk](https://img.shields.io/badge/Snyk-4C4A73?style=flat&logo=snyk&logoColor=white)](https://snyk.io)
-[![Tessl](https://img.shields.io/badge/Tessl-111111?style=flat)](https://tessl.io)

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -5,6 +5,35 @@
 Follow this shared flow. Use local validation when useful; for complete Live
 scan coverage, configure all five vendor paths.
 
+<!-- Primary stack -->
+[![Cursor](https://img.shields.io/badge/Cursor-000000?style=flat)](https://cursor.com)
+[![Modal](https://img.shields.io/badge/Modal-7C5CFF?style=flat)](https://modal.com)
+[![Supabase](https://img.shields.io/badge/Supabase-3ECF8E?style=flat&logo=supabase&logoColor=white)](https://supabase.com)
+[![Tripwire](https://img.shields.io/badge/Tripwire-1a1a2e?style=flat)](https://github.com/neomatrix369/tripwire)
+
+<!-- Scanner & partner -->
+[![Cisco](https://img.shields.io/badge/Cisco-1BA0D7?style=flat)](https://developer.cisco.com)
+[![Snyk](https://img.shields.io/badge/Snyk-4C4A73?style=flat&logo=snyk&logoColor=white)](https://snyk.io)
+[![Tessl](https://img.shields.io/badge/Tessl-111111?style=flat)](https://tessl.io)
+
+## First Live scan
+
+Do these steps in order. Do not run a Live scan or expect the Live dashboard to load
+findings until the platform accounts, `.env`, schema, and Modal app are ready.
+
+1. [Confirm the prerequisites](docs/user-guide/prerequisites.md), then clone the
+   repository and [install/link the CLI](docs/user-guide/setup-commands.md#repository-and-cli-bootstrap).
+2. Create a [Supabase project](docs/user-guide/supabase-setup.md) and
+   [Modal account](docs/user-guide/modal-setup.md). For complete scanner coverage,
+   procure Snyk, Tessl, and Cisco credentials through
+   [env-vars.md](docs/user-guide/env-vars.md#vendor-procurement-quick-steps).
+3. Only after collecting the required values, create `.env` and populate it using
+   [env-vars.md](docs/user-guide/env-vars.md). Review provider billing and quotas
+   before enabling Live services.
+4. Apply the schema and deploy the scan app using the
+   [Live environment bootstrap](docs/user-guide/setup-commands.md#live-environment-bootstrap).
+5. Run the [fixture scan and Live dashboard](#live-capabilities).
+
 ## Shared setup reference
 
 - [Setup command catalog](docs/user-guide/setup-commands.md)
@@ -18,7 +47,7 @@ scan coverage, configure all five vendor paths.
 - [Maintenance and bootstrap commands](docs/user-guide/setup-commands.md#re-run-and-maintenance-commands)
 - [Regular checks](docs/user-guide/setup-commands.md#5-test-commands-when-needed)
 
-## Install and configure
+## Installation and configuration detail
 
 1. [Confirm prerequisites](docs/user-guide/prerequisites.md).
 2. Install and link the CLI using the [setup command catalog](docs/user-guide/setup-commands.md).
@@ -65,9 +94,10 @@ tripwire setup
 ./scripts/setup-modal.sh
 ```
 
-## Validate locally
+## Validate locally (optional)
 
-Use either option before configuring Live services.
+Use either option when you want to validate local tooling or preview the dashboard.
+It does not replace the account, `.env`, and deployment steps required for Live scans.
 
 Prefer the detailed local path in one place:
 
@@ -106,16 +136,3 @@ setup, re-run, and maintenance command catalog.
 - Architecture: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
 - Capability status: [docs/STATUS.md](docs/STATUS.md)
 - Contributing: [CONTRIBUTING.md](CONTRIBUTING.md)
-
----
-
-<!-- Primary stack -->
-[![Cursor](https://img.shields.io/badge/Cursor-000000?style=flat)](https://cursor.com)
-[![Modal](https://img.shields.io/badge/Modal-7C5CFF?style=flat)](https://modal.com)
-[![Supabase](https://img.shields.io/badge/Supabase-3ECF8E?style=flat&logo=supabase&logoColor=white)](https://supabase.com)
-[![Tripwire](https://img.shields.io/badge/Tripwire-1a1a2e?style=flat)](https://github.com/neomatrix369/tripwire)
-
-<!-- Scanner & partner -->
-[![Cisco](https://img.shields.io/badge/Cisco-1BA0D7?style=flat)](https://developer.cisco.com)
-[![Snyk](https://img.shields.io/badge/Snyk-4C4A73?style=flat&logo=snyk&logoColor=white)](https://snyk.io)
-[![Tessl](https://img.shields.io/badge/Tessl-111111?style=flat)](https://tessl.io)

--- a/README.md
+++ b/README.md
@@ -2,10 +2,39 @@
 
 > Discover and scan AI skills and MCP servers, then review the findings in one dashboard.
 
-## Start safely
+[![CI](https://img.shields.io/github/actions/workflow/status/neomatrix369/tripwire/ci.yml?branch=main&label=CI)](https://github.com/neomatrix369/tripwire/actions/workflows/ci.yml)
+[![Nightly](https://img.shields.io/github/actions/workflow/status/neomatrix369/tripwire/nightly.yml?branch=main&label=Nightly)](https://github.com/neomatrix369/tripwire/actions/workflows/nightly.yml)
+[![Cursor](https://img.shields.io/badge/Cursor-000000?style=flat&logo=cursor&logoColor=white)](https://cursor.com)
+[![Modal](https://img.shields.io/badge/Modal-7C5CFF?style=flat)](https://modal.com)
+[![Supabase](https://img.shields.io/badge/Supabase-3ECF8E?style=flat&logo=supabase&logoColor=white)](https://supabase.com)
+[![Cisco Skill/MCP Scanner](https://img.shields.io/badge/Cisco%20Skill%2FMCP%20Scanner-1BA0D7?style=flat&logo=cisco&logoColor=white)](https://developer.cisco.com)
+[![Snyk](https://img.shields.io/badge/Snyk-4C4A73?style=flat&logo=snyk&logoColor=white)](https://snyk.io)
+[![Tessl](https://img.shields.io/badge/Tessl-111111?style=flat)](https://tessl.io)
 
-With [Node 22](docs/user-guide/prerequisites.md) installed, open the credential-free
-Mock dashboard:
+## Run your first Live scan
+
+Follow this order before running a scan or opening the Live dashboard. The
+[Quickstart](QUICKSTART.md#first-live-scan) supplies the commands; the linked guides
+explain each decision before you make it.
+
+1. Check the required tools and [install the CLI](docs/user-guide/setup-commands.md#repository-and-cli-bootstrap).
+2. Create the accounts you need: [Supabase](docs/user-guide/supabase-setup.md),
+   [Modal](docs/user-guide/modal-setup.md), then optional scanner providers through
+   [environment-variable procurement](docs/user-guide/env-vars.md#vendor-procurement-quick-steps).
+3. Create `.env` only after you have the values, then fill it with
+   [env-vars.md](docs/user-guide/env-vars.md) as the single key reference.
+4. Bootstrap Supabase and deploy the Modal scan app with the
+   [Live setup commands](docs/user-guide/setup-commands.md#live-environment-bootstrap).
+5. Run a fixture scan and open the Live dashboard from the
+   [Quickstart](QUICKSTART.md#live-capabilities).
+
+Supabase and Modal are required for Live results. Missing optional scanner credentials
+are reported as skipped rather than silently treated as a complete scan.
+
+## Preview the dashboard (optional)
+
+Use Mock demo data only when you want a no-account look at the UI; it does not replace
+the Live setup above or produce a scan result.
 
 ```bash
 git clone https://github.com/neomatrix369/tripwire.git
@@ -14,14 +43,6 @@ node scripts/serve-dashboard.mjs
 ```
 
 Open [http://127.0.0.1:8765/Tripwire.dc.html](http://127.0.0.1:8765/Tripwire.dc.html).
-It starts with Mock demo data when Supabase is not configured; select Live only after
-you have configured it. No account or secret is needed for this first look.
-
-| Instead of… | You can… |
-|---|---|
-| Starting with provider credentials | Explore a local Mock dashboard first |
-| Guessing what to scan | Discover skills and MCP servers with the CLI |
-| Losing scan evidence across tools | Review findings in one dashboard |
 
 ## What happens next
 
@@ -39,8 +60,8 @@ flowchart LR
 
 | Your task | Start here |
 |---|---|
-| Try Tripwire locally | [Validate locally in QUICKSTART](QUICKSTART.md#validate-locally) |
-| Set up Live scanning | [Live capabilities in QUICKSTART](QUICKSTART.md#live-capabilities) |
+| Run your first Live scan | [Follow the Quickstart](QUICKSTART.md#first-live-scan) |
+| Preview the dashboard or validate locally | [Optional local validation](QUICKSTART.md#validate-locally) |
 | Understand results and system shape | [Capability status](docs/STATUS.md) · [Architecture](docs/ARCHITECTURE.md) |
 | Contribute or maintain the project | [Contributing](CONTRIBUTING.md) · [command catalog](docs/user-guide/setup-commands.md) |
 
@@ -48,14 +69,3 @@ For the full documentation map, see [docs/README.md](docs/README.md). The
 [prerequisites](docs/user-guide/prerequisites.md), [environment-variable guide](docs/user-guide/env-vars.md),
 and [setup command catalog](docs/user-guide/setup-commands.md) hold the detailed setup
 and maintenance instructions.
-
-## Proof and integrations
-
-[![CI](https://img.shields.io/github/actions/workflow/status/neomatrix369/tripwire/ci.yml?branch=main&label=CI)](https://github.com/neomatrix369/tripwire/actions/workflows/ci.yml)
-[![Nightly](https://img.shields.io/github/actions/workflow/status/neomatrix369/tripwire/nightly.yml?branch=main&label=Nightly)](https://github.com/neomatrix369/tripwire/actions/workflows/nightly.yml)
-[![Cursor](https://img.shields.io/badge/Cursor-000000?style=flat&logo=cursor&logoColor=white)](https://cursor.com)
-[![Modal](https://img.shields.io/badge/Modal-7C5CFF?style=flat)](https://modal.com)
-[![Supabase](https://img.shields.io/badge/Supabase-3ECF8E?style=flat&logo=supabase&logoColor=white)](https://supabase.com)
-[![Cisco Skill/MCP Scanner](https://img.shields.io/badge/Cisco%20Skill%2FMCP%20Scanner-1BA0D7?style=flat&logo=cisco&logoColor=white)](https://developer.cisco.com)
-[![Snyk](https://img.shields.io/badge/Snyk-4C4A73?style=flat&logo=snyk&logoColor=white)](https://snyk.io)
-[![Tessl](https://img.shields.io/badge/Tessl-111111?style=flat)](https://tessl.io)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,29 @@
 [![Snyk](https://img.shields.io/badge/Snyk-4C4A73?style=flat&logo=snyk&logoColor=white)](https://snyk.io)
 [![Tessl](https://img.shields.io/badge/Tessl-111111?style=flat)](https://tessl.io)
 
+## What Tripwire does
+
+Tripwire helps technical teams assess AI skills and MCP servers before they rely
+on them. It discovers targets, runs the enabled scanner adapters in an isolated
+scan environment, stores the findings, and brings them together in one dashboard.
+
+## Who Tripwire is for
+
+Tripwire is currently an early-adopter tool with a hands-on setup and management
+component. It is a good fit if you can work in a terminal, manage local tooling
+and environment variables, create cloud/vendor accounts, and use command output
+to resolve a setup issue.
+
+| You are... | You want to... |
+|---|---|
+| An AI-tooling developer or team | Assess skills and MCP servers before using or sharing them |
+| A platform, operations, or security practitioner | Run and maintain scans for a team |
+| A contributor | Extend scanner support, the CLI, or the dashboard |
+
+You do not need to be a security specialist, but you should be ready to interpret
+findings and decide when to escalate them. The optional Mock preview is available
+for evaluating the dashboard without accounts; real scans require the setup below.
+
 ## Run your first Live scan
 
 Follow this order before running a scan or opening the Live dashboard. The
@@ -43,6 +66,13 @@ node scripts/serve-dashboard.mjs
 ```
 
 Open [http://127.0.0.1:8765/Tripwire.dc.html](http://127.0.0.1:8765/Tripwire.dc.html).
+
+After installing the CLI, you can also validate target discovery locally without
+accounts or a scan:
+
+```bash
+tripwire scan --dry-discover ./fixtures/skills/safe-csv-cleaner
+```
 
 ## What happens next
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ explain each decision before you make it.
 
 1. Check the required tools and [install the CLI](docs/user-guide/setup-commands.md#repository-and-cli-bootstrap).
 2. Create the accounts you need: [Supabase](docs/user-guide/supabase-setup.md),
-   [Modal](docs/user-guide/modal-setup.md), then optional scanner providers through
-   [environment-variable procurement](docs/user-guide/env-vars.md#vendor-procurement-quick-steps).
+   [Modal](docs/user-guide/modal-setup.md), then add Snyk, Tessl, and Cisco credentials
+   with the [environment-variable procurement guide](docs/user-guide/env-vars.md#vendor-procurement-quick-steps).
 3. Create `.env` only after you have the values, then fill it with
    [env-vars.md](docs/user-guide/env-vars.md) as the single key reference.
 4. Bootstrap Supabase and deploy the Modal scan app with the
@@ -28,8 +28,8 @@ explain each decision before you make it.
 5. Run a fixture scan and open the Live dashboard from the
    [Quickstart](QUICKSTART.md#live-capabilities).
 
-Supabase and Modal are required for Live results. Missing optional scanner credentials
-are reported as skipped rather than silently treated as a complete scan.
+Supabase and Modal are required for Live results. If Snyk, Tessl, or Cisco credentials
+are absent, Tripwire reports that scanner as skipped rather than calling the scan complete.
 
 ## Preview the dashboard (optional)
 
@@ -48,7 +48,7 @@ Open [http://127.0.0.1:8765/Tripwire.dc.html](http://127.0.0.1:8765/Tripwire.dc.
 
 The workflow is deliberately small: discover the target, scan it with the enabled
 adapters, then review the result. Mock lets you explore the final step safely; Live
-adds Supabase, Modal, and optional scanner providers when you need real scans.
+uses Supabase, Modal, and the configured Snyk, Tessl, and Cisco scanners for real scans.
 
 ```mermaid
 flowchart LR

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ scan environment, stores the findings, and brings them together in one dashboard
 ## Who Tripwire is for
 
 Tripwire is currently an early-adopter tool with a hands-on setup and management
-component. It is a good fit if you can work in a terminal, manage local tooling
-and environment variables, create cloud/vendor accounts, and use command output
-to resolve a setup issue.
+component. It is a good fit if you are comfortable using a terminal and shell,
+managing local tooling and environment variables, editing `.env` and other
+configuration files carefully, creating cloud/vendor accounts, and using command
+output to resolve a setup issue.
 
 | You are... | You want to... |
 |---|---|

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,14 @@
 # Security
 
+[![Cursor](https://img.shields.io/badge/Cursor-000000?style=flat)](https://cursor.com)
+[![Modal](https://img.shields.io/badge/Modal-7C5CFF?style=flat)](https://modal.com)
+[![Supabase](https://img.shields.io/badge/Supabase-3ECF8E?style=flat&logo=supabase&logoColor=white)](https://supabase.com)
+[![Tripwire](https://img.shields.io/badge/Tripwire-1a1a2e?style=flat)](https://github.com/neomatrix369/tripwire)
+
+[![Cisco](https://img.shields.io/badge/Cisco-1BA0D7?style=flat)](https://developer.cisco.com)
+[![Snyk](https://img.shields.io/badge/Snyk-4C4A73?style=flat&logo=snyk&logoColor=white)](https://snyk.io)
+[![Tessl](https://img.shields.io/badge/Tessl-111111?style=flat)](https://tessl.io)
+
 ## Supported versions
 
 Only the latest `main` branch is supported for security fixes during this hackathon / early phase.
@@ -15,16 +24,3 @@ Include: affected component (CLI / sandbox / dashboard / fixtures), reproduction
 ## Intentional vulnerable fixtures
 
 Paths under `fixtures/` contain deliberate insecure patterns for scanner demos. They use fake credentials and non-resolving hosts — treat them as test data only, never as production templates.
-
----
-
-<!-- Primary stack -->
-[![Cursor](https://img.shields.io/badge/Cursor-000000?style=flat)](https://cursor.com)
-[![Modal](https://img.shields.io/badge/Modal-7C5CFF?style=flat)](https://modal.com)
-[![Supabase](https://img.shields.io/badge/Supabase-3ECF8E?style=flat&logo=supabase&logoColor=white)](https://supabase.com)
-[![Tripwire](https://img.shields.io/badge/Tripwire-1a1a2e?style=flat)](https://github.com/neomatrix369/tripwire)
-
-<!-- Scanner & partner -->
-[![Cisco](https://img.shields.io/badge/Cisco-1BA0D7?style=flat)](https://developer.cisco.com)
-[![Snyk](https://img.shields.io/badge/Snyk-4C4A73?style=flat&logo=snyk&logoColor=white)](https://snyk.io)
-[![Tessl](https://img.shields.io/badge/Tessl-111111?style=flat)](https://tessl.io)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,6 +4,15 @@ System shape for Tripwire. Diagrams are Mermaid (text, version-controlled).
 
 Repo entry: [README.md](../README.md) · Status: [STATUS.md](./STATUS.md)
 
+[![Cursor](https://img.shields.io/badge/Cursor-000000?style=flat)](https://cursor.com)
+[![Modal](https://img.shields.io/badge/Modal-7C5CFF?style=flat)](https://modal.com)
+[![Supabase](https://img.shields.io/badge/Supabase-3ECF8E?style=flat&logo=supabase&logoColor=white)](https://supabase.com)
+[![Tripwire](https://img.shields.io/badge/Tripwire-1a1a2e?style=flat)](https://github.com/neomatrix369/tripwire)
+
+[![Cisco](https://img.shields.io/badge/Cisco-1BA0D7?style=flat)](https://developer.cisco.com)
+[![Snyk](https://img.shields.io/badge/Snyk-4C4A73?style=flat&logo=snyk&logoColor=white)](https://snyk.io)
+[![Tessl](https://img.shields.io/badge/Tessl-111111?style=flat)](https://tessl.io)
+
 ---
 
 ## 1. Context (C4 L1)
@@ -125,16 +134,3 @@ from the code.
 - Slice progress: [plan/PROGRESS.md](./plan/PROGRESS.md)
 - Formal ADRs (`docs/adr/`) — none yet; add when a major technology or boundary
   choice needs a durable record
-
----
-
-<!-- Primary stack -->
-[![Cursor](https://img.shields.io/badge/Cursor-000000?style=flat)](https://cursor.com)
-[![Modal](https://img.shields.io/badge/Modal-7C5CFF?style=flat)](https://modal.com)
-[![Supabase](https://img.shields.io/badge/Supabase-3ECF8E?style=flat&logo=supabase&logoColor=white)](https://supabase.com)
-[![Tripwire](https://img.shields.io/badge/Tripwire-1a1a2e?style=flat)](https://github.com/neomatrix369/tripwire)
-
-<!-- Scanner & partner -->
-[![Cisco](https://img.shields.io/badge/Cisco-1BA0D7?style=flat)](https://developer.cisco.com)
-[![Snyk](https://img.shields.io/badge/Snyk-4C4A73?style=flat&logo=snyk&logoColor=white)](https://snyk.io)
-[![Tessl](https://img.shields.io/badge/Tessl-111111?style=flat)](https://tessl.io)

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,12 +2,15 @@
 
 Use this map to move from a safe first look to the level of setup or project detail you need.
 
+[![CI](https://img.shields.io/github/actions/workflow/status/neomatrix369/tripwire/ci.yml?branch=main&label=CI)](https://github.com/neomatrix369/tripwire/actions/workflows/ci.yml)
+[![Nightly](https://img.shields.io/github/actions/workflow/status/neomatrix369/tripwire/nightly.yml?branch=main&label=Nightly)](https://github.com/neomatrix369/tripwire/actions/workflows/nightly.yml)
+
 ## Choose a task
 
 | Your task | Start here | Then |
 |---|---|---|
-| Try locally | [README: Mock dashboard](../README.md#start-safely) | [Validate locally](../QUICKSTART.md#validate-locally) |
-| Set up Live scanning | [Live capabilities](../QUICKSTART.md#live-capabilities) | [Supabase setup](./user-guide/supabase-setup.md) → [Modal setup](./user-guide/modal-setup.md) → [environment keys](./user-guide/env-vars.md) |
+| Run a first Live scan | [Quickstart: ordered Live setup](../QUICKSTART.md#first-live-scan) | [Supabase setup](./user-guide/supabase-setup.md) → [Modal setup](./user-guide/modal-setup.md) → [environment keys](./user-guide/env-vars.md) → [scan and dashboard](../QUICKSTART.md#live-capabilities) |
+| Preview or validate locally | [Optional local validation](../QUICKSTART.md#validate-locally-optional) | [README: dashboard preview](../README.md#preview-the-dashboard-optional) |
 | Understand results and system shape | [Capability status](./STATUS.md) | [Architecture](./ARCHITECTURE.md) |
 | Contribute or maintain | [Contributing](../CONTRIBUTING.md) | [Setup and maintenance commands](./user-guide/setup-commands.md) |
 
@@ -36,9 +39,6 @@ Use this map to move from a safe first look to the level of setup or project det
 | Check scanner adapter research | [scanner output adapters](./research/adapters/scanner-output-adapters.md) |
 
 ## CI workflows
-
-[![CI](https://img.shields.io/github/actions/workflow/status/neomatrix369/tripwire/ci.yml?branch=main&label=CI)](https://github.com/neomatrix369/tripwire/actions/workflows/ci.yml)
-[![Nightly](https://img.shields.io/github/actions/workflow/status/neomatrix369/tripwire/nightly.yml?branch=main&label=Nightly)](https://github.com/neomatrix369/tripwire/actions/workflows/nightly.yml)
 
 | Workflow | Role |
 |---|---|

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -5,6 +5,15 @@ RESEARCH · PROPOSED · DECIDED · IMPLEMENTED · VERIFIED · SUPERSEDED.
 
 Repo entry: [README.md](../README.md) · Get started: [QUICKSTART.md](../QUICKSTART.md)
 
+[![Cursor](https://img.shields.io/badge/Cursor-000000?style=flat)](https://cursor.com)
+[![Modal](https://img.shields.io/badge/Modal-7C5CFF?style=flat)](https://modal.com)
+[![Supabase](https://img.shields.io/badge/Supabase-3ECF8E?style=flat&logo=supabase&logoColor=white)](https://supabase.com)
+[![Tripwire](https://img.shields.io/badge/Tripwire-1a1a2e?style=flat)](https://github.com/neomatrix369/tripwire)
+
+[![Cisco](https://img.shields.io/badge/Cisco-1BA0D7?style=flat)](https://developer.cisco.com)
+[![Snyk](https://img.shields.io/badge/Snyk-4C4A73?style=flat&logo=snyk&logoColor=white)](https://snyk.io)
+[![Tessl](https://img.shields.io/badge/Tessl-111111?style=flat)](https://tessl.io)
+
 ---
 
 ## IMPLEMENTED
@@ -100,16 +109,3 @@ Coverage audit matrix: [plan/coverage-audit.md](./plan/coverage-audit.md)
 (slice 7 ✅). Slice stubs: [plan/README.md](./plan/README.md) (`01-A-…` … `06-F-claim-audit/`).
 Claim audit (slice 15) is the Must close-path step after slice 14; slice 16
 remediations remain deferred.
-
----
-
-<!-- Primary stack -->
-[![Cursor](https://img.shields.io/badge/Cursor-000000?style=flat)](https://cursor.com)
-[![Modal](https://img.shields.io/badge/Modal-7C5CFF?style=flat)](https://modal.com)
-[![Supabase](https://img.shields.io/badge/Supabase-3ECF8E?style=flat&logo=supabase&logoColor=white)](https://supabase.com)
-[![Tripwire](https://img.shields.io/badge/Tripwire-1a1a2e?style=flat)](https://github.com/neomatrix369/tripwire)
-
-<!-- Scanner & partner -->
-[![Cisco](https://img.shields.io/badge/Cisco-1BA0D7?style=flat)](https://developer.cisco.com)
-[![Snyk](https://img.shields.io/badge/Snyk-4C4A73?style=flat&logo=snyk&logoColor=white)](https://snyk.io)
-[![Tessl](https://img.shields.io/badge/Tessl-111111?style=flat)](https://tessl.io)

--- a/docs/plan/gate-evidence/slice-17.json
+++ b/docs/plan/gate-evidence/slice-17.json
@@ -1,9 +1,9 @@
 {
   "slice": 17,
   "date": "2026-08-03",
-  "branch": "slice/17-onboarding-documentation-ux",
+  "branch": "slice/17-phase-1b-live-setup",
   "verdict": "IN_PROGRESS",
-  "before_checks": "Phase 1 baseline merged in PR #38; Phase 1b documentation UX inventory is complete and fresh documentation review remains pending",
+  "before_checks": "Phase 1 baseline merged in PR #38; initial Phase 1b documentation UX merged in PR #40; Live-first correction inventory is complete and fresh documentation review remains pending",
   "after_checks": [
     "user-guide files exist (prerequisites, supabase-setup, modal-setup, env-vars, path-commands, onboarding-cheatsheet, setup-commands)",
     "env-vars.md is the sole vendor-procurement and key-to-feature reference",
@@ -80,10 +80,19 @@
     {
       "cmd": "node scripts/serve-dashboard.mjs --port 8766",
       "result": "blocked-by-env: sandbox rejected localhost bind with EPERM; the server's documented Mock-without-credentials path is unchanged"
+    },
+    {
+      "cmd": "git diff --check main...HEAD && jq empty docs/plan/gate-evidence/slice-17.json && pre-commit run markdownlint --all-files",
+      "result": "PASS: Live-first follow-up has no whitespace errors, valid evidence JSON, and repository-wide markdownlint passes"
+    },
+    {
+      "cmd": "rg -n '\\[!\\[' README.md QUICKSTART.md CONTRIBUTING.md SECURITY.md docs/ARCHITECTURE.md docs/README.md docs/STATUS.md fixtures/README.md prototypes/README.md",
+      "result": "PASS: every existing badge roster is top-of-page; badge links and roster membership are unchanged"
     }
   ],
   "review": "PENDING: fresh documentation-scope review required for Phase 1b",
-  "follow_up_commit": "f036501 docs(slice-17): centralize vendor credential guidance",
-  "pr": 40,
+  "baseline_pr": 40,
+  "follow_up_commit": "c28ed2b docs(slice-17): lead users through Live setup",
+  "pr": null,
   "spec_path": "docs/plan/slices/04-D-operator-onboarding/slice-17-user-guide-onboarding.md"
 }

--- a/docs/plan/gate-evidence/slice-17.json
+++ b/docs/plan/gate-evidence/slice-17.json
@@ -93,6 +93,6 @@
   "review": "PENDING: fresh documentation-scope review required for Phase 1b",
   "baseline_pr": 40,
   "follow_up_commit": "c28ed2b docs(slice-17): lead users through Live setup",
-  "pr": null,
+  "pr": 41,
   "spec_path": "docs/plan/slices/04-D-operator-onboarding/slice-17-user-guide-onboarding.md"
 }

--- a/docs/plan/gate-evidence/slice-17.json
+++ b/docs/plan/gate-evidence/slice-17.json
@@ -10,14 +10,14 @@
     "setup-commands.md owns command order and OPTIONAL_SCANNER_KEYS.md owns only Modal secret synchronization",
     "QUICKSTART links role-neutral local-validation path",
     "README Run-it → prereqs/env-vars; docs/README Choose Your Path; CONTRIBUTING step 0 ≤80",
-    "README structure updated: 4 H2 sections observed in the Phase 1b snapshot",
+    "README structure updated: 4 H2 sections observed in the Phase 1b snapshot; its proof roster is now top-of-page",
     "no Overmind/Ossprey in README/QUICKSTART/CONTRIBUTING",
     "Phase 1 baseline is merged in PR #38; PROGRESS/TRAIL mark Phase 1b documentation UX as in progress",
     "gate-evidence reflects the current task-based documentation state",
     "pgGraph, Graphify, and rag-params-finder layout and style findings are recorded with explicit adopt/avoid boundaries",
-    "README starts with a credential-free Mock-dashboard route before badges or deep setup detail",
-    "README gives an accessible Discover → Scan → Review workflow and routes to existing deeper documents",
-    "docs/README.md exposes Try locally, Set up Live scanning, Understand results/status, and Contribute/maintain task routes",
+    "README starts with project proof badges, then an ordered Live setup route before an optional Mock-dashboard preview",
+    "README gives an accessible Discover → Scan → Review workflow and routes to existing deeper documents; existing badge rosters on related public pages are top-of-page",
+    "docs/README.md exposes First Live scan, optional local preview, Understand results/status, and Contribute/maintain task routes",
     "Phase 1b Markdown, smoke-route, dry-discovery, and review evidence are captured before merge"
   ],
   "env_key_inventory": [

--- a/docs/plan/slices/04-D-operator-onboarding/slice-17-user-guide-onboarding.md
+++ b/docs/plan/slices/04-D-operator-onboarding/slice-17-user-guide-onboarding.md
@@ -7,14 +7,14 @@
 - Baseline merged: PR #38 (`0d62ddb`) — practical setup flow and Mock-without-credentials behaviour.
 - Phase 1b branch: `slice/17-onboarding-documentation-ux`
 - Phase 1b commit: `docs(slice-17): clarify first-run documentation journey`
-- Exit criteria: People comfortable with installation and ongoing maintenance can complete one practical setup flow with no private references; local validation and live capabilities are described by task rather than user role; every `.env.example` key has a row in `env-vars.md`; prerequisites, setup commands, and task-specific commands are in separate, linked docs; and a first-time visitor can start the Mock dashboard, understand the Discover → Scan → Review workflow, and find deeper documentation without badges or planning detail obscuring the path.
+- Exit criteria: People comfortable with installation and ongoing maintenance can complete one practical setup flow with no private references; local validation and live capabilities are described by task rather than user role; every `.env.example` key has a row in `env-vars.md`; prerequisites, setup commands, and task-specific commands are in separate, linked docs; and a first-time visitor can follow accounts → `.env` → bootstrap → scan → Live dashboard, understand the Discover → Scan → Review workflow, and use Mock only as an optional UI preview.
 
 ## Decisions captured
 - Adopt **rag-params-finder principles** (task → setup guide → `.env` → run; Choose Your Path) — **not** RPF’s long marketing README.
 - Lean README stays (documentation-best-practices); depth lives in `docs/user-guide/`.
 - **Phase 1 (this slice):** shared local prerequisites, `setup-commands`, task-based command guidance, `supabase-setup`, `modal-setup`, `env-vars` + wire QUICKSTART/README/docs index/CONTRIBUTING.
 - **Phase 2 (later slice, e.g. 18):** troubleshooting, CLI ref, dashboard-guide, contributor-guide, ADRs, screenshots — out of scope here.
-- **Phase 1b (this follow-up):** GitHub-native documentation UX for the public README and docs index: a calm, evidence-led first-run path, workflow-first hierarchy, and compact proof row. It is Markdown-only: no dashboard redesign, screenshots, CSS, fonts, graph engine, or dependency work.
+- **Phase 1b (this follow-up):** GitHub-native documentation UX for the public README and docs index: a calm, evidence-led Live-first path (accounts → `.env` → bootstrap → scan → dashboard), workflow-first hierarchy, and compact top-of-page proof row. Mock is an optional preview, not the setup substitute. It is Markdown-only: no dashboard redesign, screenshots, CSS, fonts, graph engine, or dependency work.
 - One practical path: install Node 22 and Python 3.12, use `tripwire scan --dry-discover` and the mock dashboard as optional local validation, then configure live capabilities when needed.
 - The local dashboard must start with built-in Mock data when Supabase credentials are absent; Live remains an explicit selectable mode once configured.
 - Supabase, Modal, and scanner credentials are capability-dependent setup steps; provision required accounts and keys **before** `cp .env.example` when using those capabilities.
@@ -45,8 +45,9 @@
 | `fixtures/OPTIONAL_SCANNER_KEYS.md` | narrowed — Modal scanner-secret allowlist and helper-only synchronization behavior |
 | `.env.example` | light cross-links to env-vars.md |
 | `QUICKSTART.md` | One practical onboarding flow; validation-only in Phase 1b unless a moved link needs correction |
-| `README.md` | Phase 1: links to setup guidance; Phase 1b: public landing-page hierarchy, credential-free Mock first run, workflow overview, compact proof row |
-| `docs/README.md` | Phase 1: practical setup sequence; Phase 1b: task-oriented documentation navigation hub |
+| `README.md` | Phase 1: links to setup guidance; Phase 1b: public landing-page hierarchy, top proof row, credential-free Mock first run, workflow overview |
+| `docs/README.md` | Phase 1: practical setup sequence; Phase 1b: top CI proof row and task-oriented documentation navigation hub |
+| `QUICKSTART.md`, `CONTRIBUTING.md`, `SECURITY.md`, `docs/{ARCHITECTURE,STATUS}.md`, `fixtures/README.md`, `prototypes/README.md` | existing badge rosters moved to the top of their pages; badges and links unchanged |
 | `CONTRIBUTING.md` | step 0 prerequisites; keep ≤80 lines |
 | `docs/plan/SMOKE_TESTS.md` | End-to-end docs smoke-test plan and script |
 | `scripts/serve-dashboard.mjs`, `prototypes/dc-dashboard/` | Mock-without-credentials dashboard serving and explicit Live selection |
@@ -57,7 +58,7 @@
 
 **Optional local validation** — Given the local prerequisites; When they run `tripwire scan --dry-discover` against a fixture or start the dashboard without Supabase credentials; Then the dashboard opens in Mock mode and they can select Live after configuring Supabase, without treating either mode as a separate audience path.
 
-**First-run documentation journey (Phase 1b)** — Given a visitor new to Tripwire; When they open the README and follow the primary Mock-dashboard action; Then they see the expected credential-free result, understand Discover → Scan → Review, and can reach the local validation, Live setup, status, architecture, and contribution paths without reading plan artifacts.
+**First-run documentation journey (Phase 1b)** — Given a visitor new to Tripwire; When they open the README and follow the primary Live setup action; Then they are led through prerequisites → provider accounts → `.env` → bootstrap → fixture scan → Live dashboard, understand Discover → Scan → Review, and can reach the optional Mock preview, status, architecture, and contribution paths without reading plan artifacts.
 
 ## Before-Checks [GATE]
 - [x] Branch `slice/17-user-guide-onboarding`
@@ -83,11 +84,11 @@
 - [x] Phase 1 baseline is recorded as merged in PR #38; PROGRESS/TRAIL show the Phase 1b documentation UX follow-up as 🔨
 - [ ] `docs/plan/gate-evidence/slice-17.json` records Phase 1b as `IN_PROGRESS` and becomes `PASS` only after its fresh review and merge
 - [x] End-to-end task-based onboarding simulation executed against docs flow and captured below
-- [x] README opens with Tripwire’s purpose and a credential-free Mock-dashboard action before badges or deep setup detail
+- [x] README opens with Tripwire’s purpose and proof badges, then an ordered Live setup action before the optional Mock preview
 - [x] pgGraph/Graphify layout and style findings are recorded above with explicit adopt/avoid boundaries
 - [x] README presents a static, accessible Discover → Scan → Review Mermaid workflow and links its deeper paths to existing documents
-- [x] README uses outcome-led capability sections and a compact proof/badge row after its primary content; no new image assets, CSS, fonts, or runtime dependencies
-- [x] `docs/README.md` exposes task routes for Try locally, Set up Live scanning, Understand results/status, and Contribute/maintain; every moved link resolves
+- [x] README uses outcome-led capability sections and a compact top-of-page proof/badge row; no new image assets, CSS, fonts, or runtime dependencies
+- [x] `docs/README.md` exposes task routes for a first Live scan, optional local preview, Understand results/status, and Contribute/maintain; every moved link resolves
 - [x] `git diff --check` and `pre-commit run markdownlint --all-files` exit 0; docs smoke route and both dry-discovery fixture commands are recorded in `gate-evidence/slice-17.json` (dashboard port limits are `blocked-by-env`)
 - [ ] Fresh documentation-scope review is recorded; Phase 1b evidence is merged before Slice 17 returns to ✅
 

--- a/docs/plan/slices/04-D-operator-onboarding/slice-17-user-guide-onboarding.md
+++ b/docs/plan/slices/04-D-operator-onboarding/slice-17-user-guide-onboarding.md
@@ -5,8 +5,9 @@
 ## Slice Workflow Bundle
 - Slice name: `slice-17-user-guide-onboarding`
 - Baseline merged: PR #38 (`0d62ddb`) — practical setup flow and Mock-without-credentials behaviour.
-- Phase 1b branch: `slice/17-onboarding-documentation-ux`
-- Phase 1b commit: `docs(slice-17): clarify first-run documentation journey`
+- Phase 1b baseline merged: PR #40 (`51a08cd`) — public documentation UX and reference-design findings.
+- Phase 1b Live-first follow-up branch: `slice/17-phase-1b-live-setup`
+- Phase 1b Live-first follow-up commit: `c28ed2b` (`docs(slice-17): lead users through Live setup`)
 - Exit criteria: People comfortable with installation and ongoing maintenance can complete one practical setup flow with no private references; local validation and live capabilities are described by task rather than user role; every `.env.example` key has a row in `env-vars.md`; prerequisites, setup commands, and task-specific commands are in separate, linked docs; and a first-time visitor can follow accounts → `.env` → bootstrap → scan → Live dashboard, understand the Discover → Scan → Review workflow, and use Mock only as an optional UI preview.
 
 ## Decisions captured
@@ -117,7 +118,7 @@
 - Templates: `.env.example`, `fixtures/OPTIONAL_SCANNER_KEYS.md`
 
 ## Gate Status
-🔨 IN PROGRESS — Phase 1b documentation UX follow-up. Phase 1 baseline merged in PR #38; Phase 1b requires fresh documentation evidence, review, and merge before ✅.
+🔨 IN PROGRESS — Phase 1b Live-first follow-up. Phase 1 baseline merged in PR #38 and the initial Phase 1b UX landed in PR #40; the correction that makes accounts → `.env` → bootstrap → scan → Live dashboard the primary journey requires fresh review and merge before ✅.
 
 ## Reviews
 

--- a/docs/plan/slices/05-E-ship-path-coverage/slice-14-coverage-status-docs-sync-onboarding-legacy.md
+++ b/docs/plan/slices/05-E-ship-path-coverage/slice-14-coverage-status-docs-sync-onboarding-legacy.md
@@ -15,9 +15,9 @@ and `docs/user-guide/*`) into a single onboarding flow that clearly answers:
 - What commands are used regularly?
 - What commands are maintenance tasks?
 
-Also remove stale optional scanner-reference material from docs/code and verify key
+Also remove stale scanner-reference material from docs/code and verify key
 inventory alignment in `.env.example` / env-var guidance.
-In addition, optional scanner onboarding must include where each vendor account is provisioned and where each scanner env var is obtained.
+In addition, scanner onboarding must include where each vendor account is provisioned and where each scanner env var is obtained.
 
 ## Scope
 

--- a/docs/user-guide/prerequisites.md
+++ b/docs/user-guide/prerequisites.md
@@ -9,13 +9,17 @@ Use this page to determine what must be ready before running any command sequenc
 ## Who can set up and run Tripwire
 
 Tripwire is for a developer, platform/operations engineer, security-minded
-technical practitioner, or other product user who is comfortable installing
-command-line tools, following setup instructions, managing environment variables
-and provider accounts, and reading command output to resolve a setup problem. You
-do not need to be a security expert to install or use Tripwire, but you should have
-enough security background or interest to interpret findings and decide when to
-escalate them. Contributors follow the same product setup before using the
-development guide.
+technical practitioner, or other product user. It is an early-adopter tool with
+a hands-on setup and management component.
+
+| Need | Required familiarity |
+|---|---|
+| Install and configure Tripwire | Terminal and shell commands; Git; Node/Python tooling; careful editing of `.env` and other configuration files |
+| Run Live scans | The above, plus cloud account setup, credential handling, and deployment/configuration troubleshooting |
+| Interpret results | Enough security background or interest to interpret findings and decide when to escalate them |
+
+You do not need to be a security expert to install or use Tripwire. Contributors
+follow the same product setup before using the development guide.
 
 ## Tools and capabilities
 

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -1,5 +1,12 @@
 # Fixtures
 
+[![Tripwire](https://img.shields.io/badge/Tripwire-1a1a2e?style=flat)](https://github.com/neomatrix369/tripwire)
+[![Supabase](https://img.shields.io/badge/Supabase-3ECF8E?style=flat&logo=supabase&logoColor=white)](https://supabase.com)
+[![Modal](https://img.shields.io/badge/Modal-000000?style=flat)](https://modal.com)
+[![Snyk](https://img.shields.io/badge/Snyk-4C4A73?style=flat&logo=snyk&logoColor=white)](https://snyk.io)
+[![Tessl](https://img.shields.io/badge/Tessl-111111?style=flat)](https://tessl.io)
+[![Cisco](https://img.shields.io/badge/Cisco-1BA0D7?style=flat)](https://developer.cisco.com)
+
 Came from [QUICKSTART](../QUICKSTART.md)? Use these paths with `tripwire scan` /
 `--dry-discover` on the shared onboarding path.
 
@@ -26,12 +33,3 @@ scanner catches the pattern, not to cause harm. Run them only inside an isolated
 Not yet built (real gaps, not urgent — see spec §8 "Known test gaps"): a purely
 live-introspected MCP server with no source at all, prompt/resource-level findings,
 cross-tool attack chains, and dependency/SCA findings.
-
----
-
-[![Tripwire](https://img.shields.io/badge/Tripwire-1a1a2e?style=flat)](https://github.com/neomatrix369/tripwire)
-[![Supabase](https://img.shields.io/badge/Supabase-3ECF8E?style=flat&logo=supabase&logoColor=white)](https://supabase.com)
-[![Modal](https://img.shields.io/badge/Modal-000000?style=flat)](https://modal.com)
-[![Snyk](https://img.shields.io/badge/Snyk-4C4A73?style=flat&logo=snyk&logoColor=white)](https://snyk.io)
-[![Tessl](https://img.shields.io/badge/Tessl-111111?style=flat)](https://tessl.io)
-[![Cisco](https://img.shields.io/badge/Cisco-1BA0D7?style=flat)](https://developer.cisco.com)

--- a/prototypes/README.md
+++ b/prototypes/README.md
@@ -2,6 +2,15 @@
 
 Reference UX and demo assets. Not the shipped product UI.
 
+[![Cursor](https://img.shields.io/badge/Cursor-000000?style=flat)](https://cursor.com)
+[![Modal](https://img.shields.io/badge/Modal-7C5CFF?style=flat)](https://modal.com)
+[![Supabase](https://img.shields.io/badge/Supabase-3ECF8E?style=flat&logo=supabase&logoColor=white)](https://supabase.com)
+[![Tripwire](https://img.shields.io/badge/Tripwire-1a1a2e?style=flat)](https://github.com/neomatrix369/tripwire)
+
+[![Cisco](https://img.shields.io/badge/Cisco-1BA0D7?style=flat)](https://developer.cisco.com)
+[![Snyk](https://img.shields.io/badge/Snyk-4C4A73?style=flat&logo=snyk&logoColor=white)](https://snyk.io)
+[![Tessl](https://img.shields.io/badge/Tessl-111111?style=flat)](https://tessl.io)
+
 Came from [QUICKSTART](../QUICKSTART.md)? Use the **Normal users** path, then return here for Live vs Mock detail.
 
 | Path            | What                                                                                                                                |
@@ -71,16 +80,3 @@ cd prototypes/dc-dashboard && npm test
 ```
 
 Covers Live config gating, mocked Supabase table fetches, item mapping, empty vs error sources, and chip copy. Optional Live smoke runs only when `tripwire-dashboard.config.js` has a real URL + key (skipped otherwise — not a CI failure).
-
----
-
-<!-- Primary stack -->
-[![Cursor](https://img.shields.io/badge/Cursor-000000?style=flat)](https://cursor.com)
-[![Modal](https://img.shields.io/badge/Modal-7C5CFF?style=flat)](https://modal.com)
-[![Supabase](https://img.shields.io/badge/Supabase-3ECF8E?style=flat&logo=supabase&logoColor=white)](https://supabase.com)
-[![Tripwire](https://img.shields.io/badge/Tripwire-1a1a2e?style=flat)](https://github.com/neomatrix369/tripwire)
-
-<!-- Scanner & partner -->
-[![Cisco](https://img.shields.io/badge/Cisco-1BA0D7?style=flat)](https://developer.cisco.com)
-[![Snyk](https://img.shields.io/badge/Snyk-4C4A73?style=flat&logo=snyk&logoColor=white)](https://snyk.io)
-[![Tessl](https://img.shields.io/badge/Tessl-111111?style=flat)](https://tessl.io)


### PR DESCRIPTION
## Summary

- Lead the README and Quickstart through accounts → `.env` → bootstrap → fixture scan → Live dashboard.
- Keep the Mock dashboard and `--dry-discover` as explicit, account-free validation paths rather than replacements for a Live scan.
- Name Snyk, Tessl, and Cisco credential setup directly, including the visible skipped-scanner outcome when a credential is absent.
- Set clear early-adopter expectations: intended operators can use shell commands, manage local tooling and cloud accounts, and edit `.env` and other configuration files carefully.

## Test Results

- Python: 123 passed; 95.91% coverage.
- CLI: 47 passed; 99.75% lines, 100% functions.
- Dashboard: 52 passed, 1 optional smoke skipped; 98.48% lines.

## Documentation verification

- Markdownlint, JSON, whitespace, guide-link targets, and both dry-discovery fixtures passed.
- The full CI suite is green.
- Local dashboard binding remains sandbox-blocked (`EPERM`); this is an environment constraint, not a product failure.