### PR TITLE
docs: add Supabase anon-key smoke test and live dashboard setup guidance

### DIFF
--- a/docs/user-guide/setup-commands.md
+++ b/docs/user-guide/setup-commands.md
@@ -55,6 +55,30 @@ tripwire setup
 # optional: ./scripts/setup-supabase.sh
 ```
 
+### Verify Supabase access
+
+After `tripwire setup`, confirm the anon key (what the browser dashboard uses)
+can read all tables. Run this whenever you change RLS settings or hit a
+"Connection error" in the dashboard:
+
+```bash
+./scripts/check-supabase.sh
+```
+
+### Live dashboard
+
+The dashboard needs a local proxy to talk to Supabase. Start it before opening
+the dashboard in Live mode — it must stay running while you use the dashboard:
+
+```bash
+node scripts/serve-dashboard.mjs
+# Open: http://127.0.0.1:8765/Tripwire.dc.html → select Live (Supabase)
+```
+
+The proxy writes `prototypes/dc-dashboard/tripwire-dashboard.config.js` on
+startup. If you restart the proxy on a different port, reload the dashboard so
+it picks up the new config.
+
 ### Modal bootstrap
 
 ```bash

--- a/docs/user-guide/supabase-setup.md
+++ b/docs/user-guide/supabase-setup.md
@@ -46,6 +46,35 @@ tripwire setup
 # After schema pulls: tripwire setup --force
 ```
 
+> **Never toggle RLS via the Supabase UI.** Enabling or disabling row-level
+> security through the dashboard creates the lock without the matching policies
+> and grants, which silently blocks the browser dashboard (anon key) while the
+> CLI still works (service role bypasses RLS). Always manage schema through
+> `tripwire setup --force` or `./scripts/setup-supabase.sh --force` — these
+> apply RLS, policies, and grants together in one idempotent step.
+
+## 5. Verify
+
+Confirm the anon key (what the browser uses) can reach all tables:
+
+```bash
+./scripts/check-supabase.sh
+```
+
+Expected output:
+
+```
+  ✓ anon SELECT items
+  ✓ anon SELECT scan_runs
+  ✓ anon SELECT scan_run_scanners
+  ✓ anon SELECT findings
+
+OK: all tables readable by the anon key.
+```
+
+If any table shows HTTP 401 or 403, the script prints the fix command
+(`tripwire setup --force`).
+
 ## Next
 
 → [modal-setup.md](./modal-setup.md) · full run: [QUICKSTART → Live capabilities](../../QUICKSTART.md#live-capabilities)

--- a/scripts/check-supabase.sh
+++ b/scripts/check-supabase.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Smoke-test Supabase connectivity from the browser's perspective.
+#
+# Uses SUPABASE_ANON_KEY (not service role) so it catches RLS policy gaps
+# that the service role bypasses silently.
+#
+# Usage (from repo root):
+#   ./scripts/check-supabase.sh
+#
+# Exit 0 = all checks passed. Exit 1 = at least one check failed.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${ROOT}/.env"
+
+if [[ -f "$ENV_FILE" ]]; then
+  # shellcheck disable=SC1090
+  set -a; source "$ENV_FILE"; set +a
+fi
+
+SUPABASE_URL="${SUPABASE_URL:-}"
+SUPABASE_ANON_KEY="${SUPABASE_ANON_KEY:-}"
+
+if [[ -z "$SUPABASE_URL" || -z "$SUPABASE_ANON_KEY" ]]; then
+  echo "error: SUPABASE_URL and SUPABASE_ANON_KEY must be set in .env" >&2
+  echo "       See docs/user-guide/supabase-setup.md" >&2
+  exit 1
+fi
+
+TABLES=(items scan_runs scan_run_scanners findings)
+FAILED=()
+
+echo "Checking Supabase anon-key access (${SUPABASE_URL})…"
+echo
+
+for table in "${TABLES[@]}"; do
+  status=$(curl -s -o /dev/null -w "%{http_code}" \
+    "${SUPABASE_URL}/rest/v1/${table}?select=id&limit=1" \
+    -H "apikey: ${SUPABASE_ANON_KEY}" \
+    -H "Authorization: Bearer ${SUPABASE_ANON_KEY}")
+
+  if [[ "$status" == "200" ]]; then
+    echo "  ✓ anon SELECT ${table}"
+  else
+    echo "  ✗ anon SELECT ${table} → HTTP ${status}"
+    FAILED+=("$table")
+  fi
+done
+
+echo
+
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+  echo "FAIL: anon key blocked on: ${FAILED[*]}"
+  echo
+  echo "This usually means RLS was enabled without the anon SELECT policies."
+  echo "Fix: re-apply the full schema (idempotent):"
+  echo
+  echo "  tripwire setup --force"
+  echo "  # or: ./scripts/setup-supabase.sh --force"
+  echo
+  echo "Never toggle RLS via the Supabase UI — always manage schema through"
+  echo "the commands above so policies and grants are applied together."
+  exit 1
+fi
+
+echo "OK: all tables readable by the anon key."

--- a/scripts/check-supabase.sh
+++ b/scripts/check-supabase.sh
@@ -15,8 +15,10 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ENV_FILE="${ROOT}/.env"
 
 if [[ -f "$ENV_FILE" ]]; then
+  set -a
   # shellcheck disable=SC1090
-  set -a; source "$ENV_FILE"; set +a
+  source "$ENV_FILE"
+  set +a
 fi
 
 SUPABASE_URL="${SUPABASE_URL:-}"


### PR DESCRIPTION
## Summary
- Add `scripts/check-supabase.sh` to smoke-test anon-key access to all four tables and catch RLS gaps the service role would hide.
- Document RLS warning and Verify step in `supabase-setup.md`; surface Verify Supabase access and Live dashboard subsections in `setup-commands.md`.
- Fix ShellCheck SC1090 so the `.env` `source` disable applies and T1 repo-lint stays green.

## Outcome
- Operators can validate browser-path Supabase access before relying on Live dashboard.
- Setup docs point to the check script and keep Live proxy requirements discoverable.
- Full local quality gates pass on the current head (`787efdc`).

## Verification
- `./scripts/quality-gates.sh --full` — exit 0 (T1/T2/T3).
- CI: Repo lint, Static analysis, Python tests, CLI tests, and Live ACL coverage passed on this head (remaining deep SAST / Meterian still settling).

## Test Results

### Backend
**Tests**: 123 passed, 0 failed, 0 skipped

**Coverage**:
| Module / Package | Statements | Branches |
|---|---|---|
| sandbox/__init__.py | 100.0% | — |
| sandbox/scan_app.py | 87.1% | 85.7% |
| sandbox/scanners.py | 99.6% | 99.3% |
| **Total** | **95.91%** | **96.32%** |

### Frontend (CLI)
**Tests**: 47 passed, 0 failed, 0 skipped

**Coverage**: from latest green `quality-gates --full` CLI run (no test code changed by the ShellCheck fix).

### Live ACL (dashboard)
**CI**: Live ACL coverage job passed on this head.

## Documentation
- `docs/user-guide/supabase-setup.md` and `setup-commands.md` updated for verify + Live dashboard guidance.
- No further doc drift known for this change set.

## Test plan
- [x] `./scripts/check-supabase.sh` exits 0 on a correctly configured project
- [ ] Script exits 1 with a clear fix command (`tripwire setup --force`) when anon key is blocked
- [x] Docs prose reviewed
- [x] `./scripts/quality-gates.sh --full` green after ShellCheck fix