### PR TITLE
chore(release): bump to v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-05
+
 ### Added
 - `cli/eslint.config.js` — flat-format ESLint 10 enforcement gate (`@eslint/js` + `globals.node`); `complexity: ['error', 10]` and `max-depth: ['error', 4]` now block in error mode at commit (eslint-cli hook) and CI (`npm run lint`), replacing the legacy `.eslintrc.cjs` for enforcement purposes
 - `prototypes/dc-dashboard/eslint.config.js` — flat-format ESLint enforcement gate for the live dashboard; same rules as CLI gate plus `globals.browser`; `support.js` (generated build artifact) excluded from linting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tripwire"
-version = "0.2.0"
+version = "0.3.0"
 description = "AI skill / MCP server security scanning platform"
 requires-python = ">=3.12"
 dependencies = []

--- a/uv.lock
+++ b/uv.lock
@@ -1010,7 +1010,7 @@ wheels = [
 
 [[package]]
 name = "tripwire"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- Bump version from `0.2.0` to `0.3.0` in `pyproject.toml`
- Promote `[Unreleased]` CHANGELOG entries to `[0.3.0] - 2026-08-05`

## Release Notes

## [0.3.0] - 2026-08-05

### Added
- `cli/eslint.config.js` — flat-format ESLint 10 enforcement gate (`@eslint/js` + `globals.node`); `complexity: ['error', 10]` and `max-depth: ['error', 4]` now block in error mode at commit (eslint-cli hook) and CI (`npm run lint`), replacing the legacy `.eslintrc.cjs` for enforcement purposes
- `prototypes/dc-dashboard/eslint.config.js` — flat-format ESLint enforcement gate for the live dashboard; same rules as CLI gate plus `globals.browser`; `support.js` (generated build artifact) excluded from linting
- `pylint>=3.0` dev dependency, `[tool.pylint.similarities]` config (≥6-line similarity threshold), and `pylint-duplication` pre-commit hook (Python files only); same check wired in `static-analysis` CI job
- `scripts/pip-audit.sh` — centralised Python dep audit with documented per-CVE ignore slots
- `scripts/check_coverage_threshold_drift.py` — FE↔backend coverage threshold drift guard (self-skips when CLI has no vite config)
- `.trivyignore` — Trivy CVE suppression starter with Why/Compensating-control/Unblock format enforced per entry
- `.meterian` — Meterian SCA thresholds (security + licensing ≥95, CVSS ≥7.0); `METERIAN_API_TOKEN` already wired in CI
- `.github/PULL_REQUEST_TEMPLATE.md` — PR description template aligned with `/create-pr` skill section names (`Summary`, `Test Results`, `Checklist`, `Closes`)
- `.github/CODEOWNERS` — auto-reviewer assignment (`@neomatrix369` global fallback)
- `cli/stryker.config.mjs` — Stryker config targeting `src/**/*.js` with built-in `command` test runner, 80% kill threshold, HTML + JSON reporters
- CLI mutation testing job in `nightly.yml` (`mutation-tests-cli`) — installs only `@stryker-mutator/core@^8` (no separate test-runner package), seeds sandbox fixtures, uploads HTML/JSON report artifact (30-day retention)

### Changed
- `scripts/pre-push-gates.sh` — T3 now runs **gitleaks commit-range only** (pushed commits via `--log-opts FROM..TO`); full-tree SAST/SCA (`security-scan.sh`, semgrep, trivy, trufflehog) moved entirely to CI where latency is acceptable
- `scripts/pre-push-gates.sh` — CLI unit tests at push now gated on `CLI_CHANGED`; previously ran unconditionally on every push even when no `cli/` files were touched
- `.pre-commit-config.yaml` — added `xenon` (complexity), `vulture` (dead code), `pylint-duplication`, `eslint-cli`, and `eslint-dashboard` hooks at commit stage; all are file-type-gated so they fire only on matching changed files
- Xenon ceiling split: `scan_app.py + guard + __init__.py → --max-absolute C`; `scanners.py → --max-absolute D` (only `run_snyk` is D-grade; tracked for refactor) — clean files no longer inherit the worst offender's ceiling
- Pre-push CLI gate upgraded from bare `npm test` to `npm run test:coverage` (c8 ≥95%); the coverage floor now enforced locally before code reaches the remote, matching Python's push behaviour
- `ci.yml` `cli-tests` job: ESLint lint step added before `test:coverage`; `static-analysis` job: xenon split applied and pylint duplicate-code check added; `live-acl-tests` job: ESLint lint step added before `test:coverage`
- `.github/workflows/nightly.yml` Chalk job — replaced silent `|| true` with `continue-on-error: true` so Chalk failures appear as visible ⚠ warnings in the Actions UI rather than being swallowed
- `CLAUDE.md` — added `## PR Composition` section so agent skills include the project Checklist in generated PR bodies

### Fixed
- `prototypes/dc-dashboard/tripwire-status.js` `normalizeSeverity` — refactored from CC 14 to CC 6 using Set-based dispatch (`SEVERITY_RED/AMBER/GREEN`); `resolveItemStatus` reduced from CC 13 to CC 8 by extracting `resolveCompletedStatus` and `resolveNoRunStatus` and removing unnecessary destructuring defaults that inflated the ESLint complexity count
- `prototypes/dc-dashboard/tripwire-live.js` — extracted 7 named helper functions (`worstScannerSeverity`, `buildCompletedScannerSummary`, `buildScannerOutput`, `shapeScannerRow`, `resolveLastScanTime`, `getRunContext`, `shapeItem`) from the 120-line `items.map` closure; all 52 tests preserved, coverage above floors
- `cli/src/discovery.js` `discoverTargets` — refactored from CC 18 to CC 8 by extracting `resolveTarget` and `annotateWithTypes`; all 15 existing tests preserved
- `cli/src/ensureSchema.js` `applySchema` — refactored from CC 13 to CC 6 by extracting `pgSslConfig` and `pgConnectHint`; added `{ cause: err }` to preserve caught error in the chain
- `cli/src/orchestrator.js` — removed useless `contentHash = null` initialisation (always overwritten before use)
- `cli/stryker.config.mjs` — switched from non-existent `@stryker-mutator/node-test-runner` package (404 on npm) to Stryker's built-in `command` runner with `node --test test/*.test.js`; set `coverageAnalysis: "off"` (command runner limitation)
- `nightly.yml` `mutation-tests-cli` — added fixture seed step (`cp -r db fixtures cli/.stryker-tmp/`) so relative paths inside Stryker's sandbox resolve correctly and the dry-run passes without `|| true` suppression

## Checklist

- [x] `./scripts/quality-gates.sh` passes locally
- [x] New tests added or updated (or change is docs-only)
- [x] Docs updated where applicable
- [x] No secrets or credentials committed