### PR TITLE
fix(scanning): fail closed on incomplete evidence

### DIFF
--- a/cli/bin/tripwire.js
+++ b/cli/bin/tripwire.js
@@ -34,17 +34,24 @@ program
   .option('--no-defaults', 'error instead of scanning machine defaults on empty args')
   .option('--dry-discover', 'print discovered targets and exit, spawn nothing')
   .action(async (targets, opts) => {
-    const list = await discoverTargets({ targets, targetsFile: opts.targets, useDefaults: opts.defaults !== false });
-    if (opts.dryDiscover) {
-      console.log(JSON.stringify(list, null, 2));
-      return;
-    }
-    if (list.length === 0) {
-      console.error('No targets found. Pass a path/URL, or run inside a folder with agent-installed skills/MCP configs.');
+    try {
+      const concurrency = Number(opts.concurrency);
+      if (!Number.isInteger(concurrency) || concurrency < 1) {
+        throw new Error('--concurrency must be a positive integer');
+      }
+      const list = await discoverTargets({ targets, targetsFile: opts.targets, useDefaults: opts.defaults !== false });
+      if (opts.dryDiscover) {
+        console.log(JSON.stringify(list, null, 2));
+        return;
+      }
+      if (list.length === 0) {
+        throw new Error('No targets found. Pass a path/URL, or run inside a folder with agent-installed skills/MCP configs.');
+      }
+      await runScan(list, { concurrency, force: Boolean(opts.force) });
+    } catch (err) {
+      console.error(err.message || err);
       process.exitCode = 1;
-      return;
     }
-    await runScan(list, { concurrency: Number(opts.concurrency), force: Boolean(opts.force) });
   });
 
 program.parseAsync(process.argv);

--- a/cli/src/ensureSchema.js
+++ b/cli/src/ensureSchema.js
@@ -35,7 +35,10 @@ export async function probeSchema(supabase = getSupabase()) {
     .from('scan_run_scanners')
     .select('completed_at')
     .limit(1);
-  if (colErr && isMissingSchemaError(colErr)) return 'missing';
+  if (colErr) {
+    if (isMissingSchemaError(colErr)) return 'missing';
+    throw new Error(`Supabase probe failed: ${colErr.message || colErr.code || 'unknown error'}`);
+  }
 
   return 'ready';
 }

--- a/cli/src/orchestrator.js
+++ b/cli/src/orchestrator.js
@@ -57,29 +57,12 @@ async function upsertItem(supabase, target) {
   return { item: inserted, cached: false };
 }
 
-export async function runScan(targets, {
-  concurrency = 5,
-  force = false,
-  // Injectable seams for characterization tests (defaults preserve production path).
-  ensureSchemaFn = ensureSchema,
-  getSupabaseFn = getSupabase,
-  spawnFn = spawnScanSandbox,
-} = {}) {
-  await ensureSchemaFn();
-  const supabase = getSupabaseFn();
-  let batchId = null;
-  if (targets.length > 1) {
-    const { data: batch } = await supabase.from('scan_batches').insert({
-      source_path: targets.map(t => t.target).join(','), item_count: targets.length, concurrency_limit: concurrency
-    }).select().single();
-    batchId = batch.id;
-  }
-
-  const scanRunIds = await mapWithConcurrency(targets, concurrency, async (target) => {
+async function dispatchTarget(supabase, target, { batchId, force, spawnFn }) {
+  try {
     const { item, cached } = await upsertItem(supabase, target);
     if (cached && !force) {
       console.log(`[skip] ${target.target} — content unchanged since last scan`);
-      return null;
+      return { target: target.target, scanRunId: null };
     }
     const { data: run, error: runError } = await supabase.from('scan_runs').insert({
       item_id: item.id, batch_id: batchId, status: 'running'
@@ -88,13 +71,65 @@ export async function runScan(targets, {
 
     try {
       await spawnFn({ target: target.target, itemType: target.type, itemId: item.id, scanRunId: run.id });
+      return { target: target.target, scanRunId: run.id };
     } catch (err) {
       console.error(`[error] sandbox failed for ${target.target}: ${err.message}`);
       await supabase.from('scan_runs').update({ status: 'failed', completed_at: new Date().toISOString() }).eq('id', run.id);
       await supabase.rpc('tripwire_rollup_item', { p_item_id: item.id });
+      return { target: target.target, scanRunId: run.id, error: err.message };
     }
-    return run.id;
-  });
+  } catch (err) {
+    const message = err.message || String(err);
+    console.error(`[error] scan dispatch failed for ${target.target}: ${message}`);
+    return { target: target.target, scanRunId: null, error: message };
+  }
+}
 
-  console.log(JSON.stringify({ batch_id: batchId, scan_run_ids: scanRunIds.filter(Boolean) }, null, 2));
+function assertPositiveConcurrency(concurrency) {
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new Error('--concurrency must be a positive integer');
+  }
+}
+
+async function createScanBatch(supabase, targets, concurrency) {
+  const { data: batch, error } = await supabase.from('scan_batches').insert({
+    source_path: targets.map(t => t.target).join(','), item_count: targets.length, concurrency_limit: concurrency
+  }).select().single();
+  if (error) throw new Error(`Failed to create scan batch: ${error.message || error.code || 'unknown error'}`);
+  return batch.id;
+}
+
+export async function runScan(targets, {
+  concurrency = 5,
+  force = false,
+  // Injectable seams for characterization tests (defaults preserve production path).
+  ensureSchemaFn = ensureSchema,
+  getSupabaseFn = getSupabase,
+  spawnFn = spawnScanSandbox,
+} = {}) {
+  assertPositiveConcurrency(concurrency);
+  await ensureSchemaFn();
+  const supabase = getSupabaseFn();
+  let batchId = null;
+  if (targets.length > 1) {
+    batchId = await createScanBatch(supabase, targets, concurrency);
+  }
+
+  const outcomes = await mapWithConcurrency(
+    targets,
+    concurrency,
+    target => dispatchTarget(supabase, target, { batchId, force, spawnFn }),
+  );
+
+  const failures = outcomes.filter(outcome => outcome.error);
+  const result = {
+    batch_id: batchId,
+    scan_run_ids: outcomes.map(outcome => outcome.scanRunId).filter(Boolean),
+    failed_targets: failures.map(({ target, error }) => ({ target, error })),
+  };
+  console.log(JSON.stringify(result, null, 2));
+  if (failures.length) {
+    throw new Error(`${failures.length} target scan dispatch failure(s); inspect failed_targets output`);
+  }
+  return result;
 }

--- a/cli/test/ensureSchema-coverage.test.js
+++ b/cli/test/ensureSchema-coverage.test.js
@@ -63,6 +63,14 @@ test('given non-schema probe error when probeSchema then throws', async () => {
   await assert.rejects(() => probeSchema(sb), /Supabase probe failed/);
 });
 
+test('given completed_at probe auth failure when probeSchema then aborts rather than reporting ready', async () => {
+  // -- Given --
+  const sb = mockSupabase({ colError: { message: 'JWT expired' } });
+
+  // -- When / Then --
+  await assert.rejects(() => probeSchema(sb), /Supabase probe failed: JWT expired/);
+});
+
 test('given empty db url when applySchema then throws', async () => {
   // -- Given / When / Then --
   await assert.rejects(() => applySchema({ dbUrl: '' }), /Set SUPABASE_DB_URL/);

--- a/cli/test/orchestrator-coverage.test.js
+++ b/cli/test/orchestrator-coverage.test.js
@@ -26,8 +26,9 @@ function createSupabaseStub({
   itemId = 'item-1',
   runId = 'run-1',
   batchId = 'batch-1',
+  batchError = null,
 } = {}) {
-  const calls = { failedUpdates: 0, rpc: 0, batches: 0, updates: 0 };
+  const calls = { failedUpdates: 0, rpc: 0, batches: [], updates: 0 };
 
   const supabase = {
     calls,
@@ -68,10 +69,14 @@ function createSupabaseStub({
         },
         insert(row) {
           if (table === 'scan_batches') {
+            calls.batches.push(row);
             return {
               select() {
                 return {
-                  single: () => makeThenable({ data: { id: batchId, ...row }, error: null }),
+                  single: () => makeThenable({
+                    data: batchError ? null : { id: batchId, ...row },
+                    error: batchError,
+                  }),
                 };
               },
             };
@@ -145,13 +150,14 @@ test('given spawn failure when runScan then marks failed and rolls up', async ()
   const targets = [{ target: dir, type: 'skill', locus: 'local', avail: 'source_on_disk' }];
 
   // -- When --
-  await runScan(targets, {
-    ensureSchemaFn: async () => ({ status: 'ready' }),
-    getSupabaseFn: () => sb,
-    spawnFn: async () => {
-      throw new Error('modal down');
-    },
-  });
+  await assert.rejects(
+    () => runScan(targets, {
+      ensureSchemaFn: async () => ({ status: 'ready' }),
+      getSupabaseFn: () => sb,
+      spawnFn: async () => { throw new Error('modal down'); },
+    }),
+    /target scan dispatch failure/,
+  );
 
   // -- Then --
   assert.ok(sb.calls.failedUpdates >= 1);
@@ -198,15 +204,56 @@ test('given multiple targets when runScan then creates batch', async () => {
   ];
 
   // -- When --
-  await runScan(targets, {
+  const result = await runScan(targets, {
     ensureSchemaFn: async () => ({ status: 'ready' }),
     getSupabaseFn: () => sb,
     spawnFn: async () => {},
   });
 
   // -- Then --
-  assert.ok(true); // batch insert path exercised without throw
+  assert.deepEqual(sb.calls.batches, [{
+    source_path: `${a},${b}`,
+    item_count: 2,
+    concurrency_limit: 5,
+  }]);
+  assert.equal(result.batch_id, 'batch-1');
+  assert.deepEqual(result.scan_run_ids, ['run-1', 'run-1']);
+  assert.deepEqual(result.failed_targets, []);
   await rm(root, { recursive: true, force: true });
+});
+
+test('given batch persistence failure when multiple targets scan then it aborts before dispatch', async () => {
+  // -- Given --
+  const sb = createSupabaseStub({ batchError: { message: 'database unavailable' } });
+  const targets = [
+    { target: 'https://one.example/mcp', type: 'mcp_server', avail: 'introspection_only' },
+    { target: 'https://two.example/mcp', type: 'mcp_server', avail: 'introspection_only' },
+  ];
+
+  // -- When / Then --
+  await assert.rejects(
+    () => runScan(targets, {
+      ensureSchemaFn: async () => ({ status: 'ready' }),
+      getSupabaseFn: () => sb,
+      spawnFn: async () => assert.fail('dispatch must not start'),
+    }),
+    /Failed to create scan batch: database unavailable/,
+  );
+});
+
+test('given zero concurrency through the orchestration API when scan starts then it rejects before schema work', async () => {
+  // -- Given --
+  let schemaCalls = 0;
+
+  // -- When / Then --
+  await assert.rejects(
+    () => runScan([], {
+      concurrency: 0,
+      ensureSchemaFn: async () => { schemaCalls += 1; },
+    }),
+    /positive integer/,
+  );
+  assert.equal(schemaCalls, 0);
 });
 
 async function mkdirSafe(p) {

--- a/cli/test/orchestrator.test.js
+++ b/cli/test/orchestrator.test.js
@@ -1,6 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { promisify } from 'node:util';
 
 const exec = promisify(execFile);
@@ -54,4 +57,44 @@ test('setup reports its environment requirement instead of applying schema witho
       return true;
     },
   );
+});
+
+test('given invalid concurrency when scan starts then it exits before discovery or persistence', async () => {
+  // -- Given --
+  const args = [tripwireBin, 'scan', '--concurrency', '0', '--no-defaults'];
+
+  // -- When / Then --
+  await assert.rejects(
+    () => exec('node', args),
+    (error) => error.code === 1 && /positive integer/.test(error.stderr),
+  );
+});
+
+test('given malformed targets JSON when dry discovery runs then it exits with an actionable error', async () => {
+  // -- Given --
+  const dir = await mkdtemp(path.join(tmpdir(), 'tw-targets-'));
+  const targets = path.join(dir, 'targets.json');
+  await writeFile(targets, '{not-json');
+
+  // -- When / Then --
+  try {
+    await assert.rejects(
+      () => exec('node', [tripwireBin, 'scan', '--targets', targets, '--dry-discover']),
+      (error) => error.code === 1 && /JSON|property name/.test(error.stderr),
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('given an explicit MCP endpoint when dry discovery runs then it reports the discovered target without scanning', async () => {
+  // -- Given --
+  const endpoint = 'https://mcp.example.test/sse';
+
+  // -- When --
+  const { stdout } = await exec('node', [tripwireBin, 'scan', endpoint, '--dry-discover']);
+
+  // -- Then --
+  assert.match(stdout, /mcp\.example\.test/);
+  assert.match(stdout, /introspection_only/);
 });

--- a/docs/plan/coverage-audit.md
+++ b/docs/plan/coverage-audit.md
@@ -1,6 +1,6 @@
 # Coverage audit matrix (slice 7)
 
-> Last updated: 2026-08-03 · Horizon A · Ship-path target ~95% (DECIDED)
+> Last updated: 2026-08-07 · Horizon A · Ship-path target ~95% (DECIDED)
 > Context: private references SoT + public STATUS/ARCHITECTURE
 
 ## Altitude / targets
@@ -8,8 +8,8 @@
 | Layer | Target | Status |
 |-------|--------|--------|
 | Python `sandbox/` (ship path; omit `guard/`) | ≥95% branch when gated | ✅ gate achieved — slice 11 (`95.91%`, fail_under=95; branch/lines/statements aligned to gate policy) |
-| Node `cli/src` | ≥95% lines/stmts, with 100% funcs and 85% branches where justified | ✅ gate achieved — slice 12 (`99.75%` lines, `100%` funcs, `85%` branches) |
-| Live ACL JS (`tripwire-live/status/realtime/data`) | ≥95% lines, with residual funcs/branches justified | ✅ gate achieved — slice 13 (`98.48%` lines, `85%` funcs, `80%` branches) |
+| Full Node CLI (`cli/src` + `cli/bin/tripwire.js`) | ≥95% lines/stmts, with 100% funcs and 85% branches where justified | ✅ gate achieved (`98.60%` lines, `100%` funcs, `85.71%` branches) |
+| Prototype dashboard (`prototypes/dc-dashboard`) | Normal tests run; excluded from coverage and complexity gates | Excluded by scope decision |
 | `guard/`, `support.js`, Remotion, scripts | Out of bar | Won't for this wave |
 | Live Modal/Supabase E2E as CI Must | Won't | optional skip-without-config |
 
@@ -29,6 +29,23 @@
 | Guard PreToolUse | Future / Won't for A | missing | ARCHITECTURE Future (Gate A); exclude from coverage bar |
 | Overmind Phase 5 / Ossprey | Won't / unwired | n/a | Badges stripped Gate A |
 | Coverage floors documented | DECIDED | docs | CONTRIBUTING + STATUS; raise in 11–13 |
+
+## Acceptance catalog (current governed path)
+
+The scenarios below are executable, human-readable checks for the currently governed CLI and sandbox path. They are deliberately maintained with the code, not copied from private planning references.
+
+| Requirement | Executable scenario | Level | Status |
+|-------------|---------------------|-------|--------|
+| A schema probe must never certify an unavailable database | Given `completed_at` probe returns an auth/network error, when preflight runs, then it aborts rather than reporting schema ready | CLI acceptance | Verified |
+| User input cannot create an empty successful scan | Given invalid concurrency or malformed target JSON, when `tripwire scan` starts, then it exits nonzero before discovery/persistence | CLI process acceptance | Verified |
+| Multi-target dispatch is observable | Given two discovered targets, when a batch is dispatched, then one batch stores its count/concurrency and reports its batch/run IDs | CLI persistence contract | Verified |
+| A per-target dispatch failure is not hidden | Given one sandbox dispatch fails, when scan orchestration completes, then its run is marked failed, the item rolls up, failed target detail is output, and the CLI exits nonzero | CLI orchestration acceptance | Verified |
+| Scanner output must contain usable evidence | Given Cisco Skill, Cisco MCP, or Tessl returns a zero-exit malformed/empty payload, when results are mapped, then that scanner is unreachable rather than clean | Sandbox adapter acceptance | Verified |
+| Partial Snyk results are not clean | Given one Snyk path succeeds and another errors, when results are mapped, then findings persist but the scanner is unreachable so the roll-up is partial-failed | Sandbox adapter acceptance | Verified |
+| Local input remains bounded to the sandbox | Given a path-traversal archive, when the sandbox extracts it, then extraction fails and nothing is written outside the workdir | Sandbox safety acceptance | Verified |
+| Local source reaches the real remote boundary | Given a packable local target, when the host Modal entrypoint runs, then `scan_item.remote` receives the archive and item/run identity | Sandbox wiring acceptance | Verified |
+
+Deferred, future-tracked work: full drift/trend/diff behavior and Guard enforcement. Prototype dashboard behavior remains outside coverage and complexity metrics; it still has its normal test suite.
 
 ## Internal ↔ public parity deltas
 

--- a/sandbox/scanners.py
+++ b/sandbox/scanners.py
@@ -138,7 +138,13 @@ def run_cisco_skill_scanner(workdir):
         console = _build_console(out, err)
         if code != 0:
             return [_unreachable(source, err, console_output=console)], []
-        parsed = _safe_json(out) or {}
+        parsed = _safe_json(out)
+        if not isinstance(parsed, dict) or not parsed:
+            return [
+                _unreachable(
+                    source, "scanner returned no parseable JSON results", console_output=console
+                )
+            ], []
         mapped = _map_skill_findings(parsed, source)
         checks = parsed.get("findings_count", len(parsed.get("findings", [])) or 1)
         return [_completed(source, checks, mapped, console_output=console)], mapped
@@ -354,11 +360,22 @@ def run_cisco_mcp_scanner(workdir, target):
                     )
                 )
         else:
-            f, r, _requested = _map_mcp_envelope(_safe_json(out) or {}, live)
-            for row in r:
-                row["console_output"] = console
-            findings += f
-            rows += r
+            envelope = _safe_json(out)
+            if not isinstance(envelope, dict) or not isinstance(envelope.get("scan_results"), list):
+                for name in live:
+                    rows.append(
+                        _unreachable(
+                            _MCP_ANALYZER_LABEL[_normalize_analyzer_key(name)],
+                            "scanner returned no parseable scan_results",
+                            console_output=console,
+                        )
+                    )
+            else:
+                f, r, _requested = _map_mcp_envelope(envelope, live)
+                for row in r:
+                    row["console_output"] = console
+                findings += f
+                rows += r
 
     reported = {row["scanner_source"] for row in rows}
     for key in _MCP_LIVE_KEYS:
@@ -377,15 +394,24 @@ def run_cisco_mcp_scanner(workdir, target):
         if code != 0:
             rows.append(_unreachable(beh_label, err, console_output=beh_console))
         else:
-            envelope = _safe_json(out) or {}
-            if not envelope.get("requested_analyzers"):
-                envelope = {**envelope, "requested_analyzers": ["behavioral"]}
-            f, r, _ = _map_mcp_envelope(envelope, ["behavioral"])
-            findings += f
-            beh_rows = [row for row in r if row["scanner_source"] == beh_label]
-            for row in beh_rows:
-                row["console_output"] = beh_console
-            rows += beh_rows or [_completed(beh_label, 1, [], console_output=beh_console)]
+            envelope = _safe_json(out)
+            if not isinstance(envelope, dict) or not isinstance(envelope.get("scan_results"), list):
+                rows.append(
+                    _unreachable(
+                        beh_label,
+                        "scanner returned no parseable scan_results",
+                        console_output=beh_console,
+                    )
+                )
+            else:
+                if not envelope.get("requested_analyzers"):
+                    envelope = {**envelope, "requested_analyzers": ["behavioral"]}
+                f, r, _ = _map_mcp_envelope(envelope, ["behavioral"])
+                findings += f
+                beh_rows = [row for row in r if row["scanner_source"] == beh_label]
+                for row in beh_rows:
+                    row["console_output"] = beh_console
+                rows += beh_rows or [_completed(beh_label, 1, [], console_output=beh_console)]
 
     return findings, rows
 
@@ -449,9 +475,17 @@ def run_snyk(workdir, item_type="mcp_server"):
                 }
             )
 
-    if findings or checks or not path_errors:
+    if path_errors:
+        return findings, [
+            _unreachable(
+                source,
+                "; ".join(path_errors),
+                console_output=console,
+            )
+        ]
+    if findings or checks:
         return findings, [_completed(source, checks or 1, findings, console_output=console)]
-    return [], [
+    return findings, [
         _unreachable(
             source,
             "; ".join(path_errors) or err or out or f"exit {code}",
@@ -491,9 +525,17 @@ def run_tessl(workdir):
     console = _build_console(out, err)
     if code != 0:
         return None, [_unreachable("Tessl", err or out, console_output=console)]
-    parsed = _safe_json(out) or {}
+    parsed = _safe_json(out)
     score = _tessl_quality_score(parsed)
-    detail = f"quality_score = {score}" if score is not None else "1 check completed"
+    if score is None:
+        return None, [
+            _unreachable(
+                "Tessl",
+                "scanner returned no parseable quality score",
+                console_output=console,
+            )
+        ]
+    detail = f"quality_score = {score}"
     row = {"scanner_source": "Tessl", "status": "completed", "checks_run": 1, "detail": detail}
     if console:
         row["console_output"] = console

--- a/sandbox/tests/test_acquire_target.py
+++ b/sandbox/tests/test_acquire_target.py
@@ -12,7 +12,9 @@ using tmp dirs and subprocess mocking — no network, no Modal, no Supabase.
 import os
 import subprocess
 import sys
+import tarfile
 import types
+from io import BytesIO
 from unittest.mock import patch
 
 import pytest
@@ -78,6 +80,7 @@ from scan_app import (  # noqa: E402
     _looks_like_filesystem_path,
     _maybe_pack_local_target,
     _pack_local_dir,
+    main,
 )
 
 # ── _is_git_url classification ──────────────────────────────────────────────
@@ -217,6 +220,34 @@ def test_pack_and_extract_roundtrip_preserves_skill_md(tmp_path):
     assert os.path.isfile(os.path.join(workdir, "notes", "extra.txt")), "nested file missing"
 
 
+def test_given_path_traversal_archive_when_extracting_then_it_is_rejected_without_writing_outside(
+    tmp_path,
+):
+    """
+    Scenario: Uploaded archives cannot escape the sandbox work directory.
+    Slice: archive acquisition safety
+
+    Given a tar archive containing a ../ path traversal member,
+    When the sandbox extracts it,
+    Then extraction raises and no file is created outside the requested workdir.
+    """
+    ### Given
+    workdir = tmp_path / "workdir"
+    workdir.mkdir()
+    escaped = tmp_path / "escaped.txt"
+    payload = BytesIO()
+    with tarfile.open(fileobj=payload, mode="w:gz") as tar:
+        member = tarfile.TarInfo("../escaped.txt")
+        data = b"unsafe"
+        member.size = len(data)
+        tar.addfile(member, BytesIO(data))
+
+    ### When / Then
+    with pytest.raises(tarfile.FilterError):
+        _extract_archive(payload.getvalue(), str(workdir))
+    assert not escaped.exists()
+
+
 def test_maybe_pack_local_target_returns_bytes_for_directory(tmp_path):
     ### Given
     src = tmp_path / "skill"
@@ -270,6 +301,35 @@ def test_acquire_target_extracts_uploaded_archive(tmp_path):
     skill_path = os.path.join(workdir, "SKILL.md")
     assert os.path.isfile(skill_path), "expected SKILL.md from uploaded archive"
     assert open(skill_path).read() == "# From host\n"
+
+
+def test_given_local_target_when_host_entrypoint_runs_then_it_hands_the_archive_to_modal() -> None:
+    """
+    Scenario: Local source crosses the host-to-sandbox boundary as an archive.
+    Slice: production Modal handoff
+
+    Given the host can pack a local target,
+    When the Modal entrypoint starts a scan,
+    Then scan_item.remote receives the target identity and exact archive bytes.
+    """
+    ### Given
+    archive = b"packed-local-target"
+
+    ### When
+    with (
+        patch("scan_app._maybe_pack_local_target", return_value=archive),
+        patch("scan_app.scan_item") as scan_item,
+    ):
+        main("fixtures/skill", "skill", "item-1", "run-1")
+
+    ### Then
+    scan_item.remote.assert_called_once_with(
+        target="fixtures/skill",
+        item_type="skill",
+        item_id="item-1",
+        scan_run_id="run-1",
+        target_archive=archive,
+    )
 
 
 def test_acquire_target_raises_when_local_path_missing_without_archive(tmp_path):

--- a/sandbox/tests/test_scanners_mcp_cli.py
+++ b/sandbox/tests/test_scanners_mcp_cli.py
@@ -208,3 +208,31 @@ def test_given_usage_stderr_when_live_fails_then_behavioral_not_marked_unreachab
         by_src["Cisco MCP Scanner: Behavioral Code Scanning"]["status"]
         == "skipped_missing_credential"
     )
+
+
+def test_given_empty_success_envelope_when_live_scan_runs_then_yara_is_not_reported_clean(
+    tmp_path,
+) -> None:
+    """
+    Scenario: An empty MCP success response has no scanner evidence.
+    Slice: scanner evidence integrity
+
+    Given mcp-scanner exits zero with an empty JSON envelope,
+    When the live MCP scan is mapped,
+    Then YARA is unreachable and its detail explains that scan results were absent.
+    """
+    ### Given
+    (tmp_path / "run.sh").write_text("#!/bin/bash\n")
+
+    ### When
+    with (
+        patch.object(scanners, "_which", return_value=True),
+        patch.object(scanners, "_run", return_value=(0, "{}", "")),
+        patch.dict(os.environ, {"MCP_SCANNER_LLM_API_KEY": ""}, clear=False),
+    ):
+        _findings, rows = scanners.run_cisco_mcp_scanner(str(tmp_path), str(tmp_path))
+
+    ### Then
+    yara = next(row for row in rows if row["scanner_source"] == "Cisco MCP Scanner: YARA")
+    assert yara["status"] == "unreachable"
+    assert "no parseable scan_results" in yara["detail"]

--- a/sandbox/tests/test_scanners_skill_parse.py
+++ b/sandbox/tests/test_scanners_skill_parse.py
@@ -92,14 +92,14 @@ def test_given_prefixed_json_when_safe_json_then_object_extracted() -> None:
     assert actual["findings"][0]["severity"] == "CRITICAL"
 
 
-def test_given_malformed_payload_when_scanner_runs_then_completed_with_no_findings() -> None:
+def test_given_malformed_payload_when_scanner_runs_then_marks_the_engine_unreachable() -> None:
     """
-    Scenario: Malformed skill-scanner stdout does not crash; yields empty map.
-    Slice: slice-8 — malformed payload
+    Scenario: A successful exit without parseable scanner evidence is not clean.
+    Slice: scanner evidence integrity
 
     Given non-JSON stdout and exit 0,
     When run_cisco_skill_scanner runs,
-    Then findings are empty and the static row completes with zero mapped findings.
+    Then findings are empty and the static row is unreachable, never a false clean result.
     """
     ### Given
     stdout = _load("malformed.txt")
@@ -118,8 +118,8 @@ def test_given_malformed_payload_when_scanner_runs_then_completed_with_no_findin
 
     ### Then
     assert findings == []
-    assert rows[0]["status"] == "completed"
-    assert "no findings" in rows[0]["detail"]
+    assert rows[0]["status"] == "unreachable"
+    assert "no parseable JSON" in rows[0]["detail"]
 
 
 @pytest.mark.parametrize(("raw", "expected"), SEVERITY_COLLAPSE_CASES)

--- a/sandbox/tests/test_ship_path_coverage.py
+++ b/sandbox/tests/test_ship_path_coverage.py
@@ -927,6 +927,37 @@ def test_given_non_dict_path_result_when_snyk_then_skipped() -> None:
     assert rows[0]["status"] == "completed"
 
 
+def test_given_mixed_snyk_path_results_when_one_path_errors_then_scan_is_partial_not_clean() -> (
+    None
+):
+    """
+    Scenario: Partial Snyk evidence cannot be certified as a clean scan.
+    Slice: scanner evidence integrity
+
+    Given one Snyk path has findings and another returns an error,
+    When the Snyk adapter maps the response,
+    Then findings are retained but the scanner status is unreachable for roll-up.
+    """
+    ### Given
+    payload = {
+        "/tmp/ok": {"issues": [{"code": "E004", "message": "prompt injection"}]},
+        "/tmp/error": {"error": "permission denied"},
+    }
+
+    ### When
+    with (
+        patch.dict("os.environ", {"SNYK_TOKEN": "t"}, clear=False),
+        patch.object(scanners, "_which", return_value=True),
+        patch.object(scanners, "_run", return_value=(0, json.dumps(payload), "")),
+    ):
+        findings, rows = scanners.run_snyk("/tmp", "mcp_server")
+
+    ### Then
+    assert len(findings) == 1
+    assert rows[0]["status"] == "unreachable"
+    assert "permission denied" in rows[0]["detail"]
+
+
 def test_given_tessl_no_console_when_completed_then_no_console_key() -> None:
     """
     Scenario: Empty Tessl console omits console_output key.
@@ -944,6 +975,29 @@ def test_given_tessl_no_console_when_completed_then_no_console_key() -> None:
     ### Then
     assert score == 1
     assert "console_output" not in rows[0]
+
+
+def test_given_tessl_empty_success_output_when_run_then_not_reported_completed() -> None:
+    """
+    Scenario: Tessl needs a parseable quality score to certify completion.
+    Slice: scanner evidence integrity
+
+    Given Tessl exits zero but writes an empty JSON object,
+    When the quality adapter maps the response,
+    Then it is unreachable instead of a one-check clean result.
+    """
+    ### Given / When
+    with (
+        patch.dict("os.environ", {"TESSL_TOKEN": "t"}, clear=False),
+        patch.object(scanners, "_which", return_value=True),
+        patch.object(scanners, "_run", return_value=(0, "{}", "")),
+    ):
+        score, rows = scanners.run_tessl("/tmp")
+
+    ### Then
+    assert score is None
+    assert rows[0]["status"] == "unreachable"
+    assert "no parseable quality score" in rows[0]["detail"]
 
 
 def test_given_on_scanner_start_when_run_all_skill_then_signalled() -> None:


### PR DESCRIPTION
## Summary

This change makes scan outcomes fail closed and operator-visible when required evidence is incomplete or execution fails.

- **Schema and scanner evidence:** aborts on non-schema probe failures and treats empty, malformed, or incomplete Cisco Skill/MCP, Tessl, and mixed Snyk output as failure evidence rather than a clean scan.
- **CLI operator outcomes:** validates concurrency and target JSON, preserves batch/run correlation, reports exact failed targets, and exits nonzero for partial dispatch failure.
- **Execution-boundary assurance:** adds acceptance coverage for archive traversal, host-to-Modal archive handoff, scanner failure mapping, and CLI dry discovery.

## Validation

| Scope | Result | Coverage |
| --- | --- | --- |
| Backend sandbox | 128 passed | 96.19% |
| Frontend CLI | 55 passed | 98.60% lines, 100% functions, 85.71% branches |
| Prototype dashboard | CI test job passed | Excluded from governed coverage/complexity thresholds |
| Repository quality gates | Passed | Static analysis, secrets, SAST/SCA, complexity, and CodeQL checks all green |

## Review focus

- Confirm a scanner cannot report a clean result without structurally valid evidence.
- Confirm partial CLI batch failure is visible to the operator and cannot return success.
- Confirm the added tests exercise public behavior rather than mock-call assertions alone.

## Checklist

- [x] `./scripts/quality-gates.sh` passes locally
- [x] New tests added or updated
- [x] Docs updated where applicable
- [x] No secrets or credentials committed