### PR TITLE
chore(release): bump to v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-08-14
+
 ### Added
 - Tiered post-scan router: `tripwire route` and auto-route after `tripwire scan`
   (SIE triage + optional Model Studio escalation; `scanner_source=tiered_router`)

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tripwire-cli",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "bin": {
     "tripwire": "./bin/tripwire.js"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tripwire"
-version = "0.3.0"
+version = "0.4.0"
 description = "AI skill / MCP server security scanning platform"
 requires-python = ">=3.12"
 dependencies = []

--- a/uv.lock
+++ b/uv.lock
@@ -1010,7 +1010,7 @@ wheels = [
 
 [[package]]
 name = "tripwire"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Bump version to **0.4.0** (minor): tiered post-scan router, dashboard router UX, ADR catalog + provider setup docs
- Promote CHANGELOG `[Unreleased]` → `[0.4.0] - 2026-08-14`
- Align `pyproject.toml`, `cli/package.json`, and `uv.lock` to 0.4.0

## Changelog

## [0.4.0] - 2026-08-14

### Added
- Tiered post-scan router: `tripwire route` and auto-route after `tripwire scan`
  (SIE triage + optional Model Studio escalation; `scanner_source=tiered_router`)
- Model Studio and SIE sample CLIs under `prototypes/model-studio/` and
  `prototypes/sie-studio/`
- Dashboard router strip, SIE-only / escalated filters, and Mock router fixtures
- Optional `.env` keys for SIE / Model Studio (documented in `docs/user-guide/env-vars.md`)
- ADR-0016: tiered router via SIE and Model Studio

### Changed
- Card `heatmap_status` is worst-of actionable findings (any red → red; amber-only
  → amber); `risk_score` stays weighted density for sort/trend. Dashboard cards
  show an actionable finding-count chip so one vs many vulns stay distinguishable
- Severity rollup excludes `tiered_router` findings so triage does not inflate
  scanner red/amber counts
- CLI coverage floors temporarily lowered (60/60/80/60) while measured CLI
  coverage recovers after the router land; `cli/test/router.test.js` exists;
  ADR-0013 ≥95% target unchanged

### Fixed
- Tiered router no longer batch-deletes `tiered_router` findings before routing;
  per-item replace-on-success preserves `Scan → SIE → ■` strips when SIE skips
- Dashboard shows `Scan → ■` / “SIE not called” on scanned cards with no
  `tiered_router` finding (SIE never invoked)

### Docs
- Formal ADR catalog under `docs/adr/`: Accepted retrospective records
  0002–0016 for shipped topology, scanning, security, CLI, quality,
  Horizon A scope, and tiered router. Number 0001 reserved (Monk Live packaging
  draft on a side branch, not published). Indexes wired from Architecture,
  STATUS, README, QUICKSTART, CONTRIBUTING, and plan README.
- Provider setup guides for optional tiered routing:
  `docs/user-guide/sie-setup.md` and `docs/user-guide/model-studio-setup.md`
  (wired from README, QUICKSTART, docs index, env-vars, prerequisites)
- Operator howto for pathway strips / Escalated / SIE-only / categories:
  `docs/user-guide/reading-router-results.md`
- Screenshot gallery refreshed: CLI help includes `route`, live Modal scan
  capture updated, dashboard/skill/MCP shots retaken from Mock demo data,
  Escalated / SIE-only / pathway filter shots; regenerate UI shots with
  `scripts/capture-screenshots.mjs`

## Test Results
- Pre-commit fast tests: Python 130 passed, CLI 67 passed
- Pre-push gates: coverage + audits + gitleaks passed

## Checklist

- [x] `./scripts/quality-gates.sh` passes locally
- [x] New tests added or updated (or change is docs-only)
- [x] Docs updated where applicable
- [x] No secrets or credentials committed

## After merge
Tag `v0.4.0` + optional GitHub release (do **not** push the bump directly to main).


Made with [Cursor](https://cursor.com)

<!-- tripwire-complexity:start -->
## Complexity

_Automatically refreshed by CI for product-code changes._

| Scope | Tool | Result |
| --- | --- | --- |
| Python (`sandbox/`) | Radon | highest CC **28** (rank **D**), 159 blocks |
| CLI (`cli/`) | ESLint | 0 function(s) above CC 10 |

<details><summary>Functions above the JavaScript threshold</summary>

- CLI: no functions exceed cyclomatic complexity 10.

</details>
<!-- tripwire-complexity:end -->