### PR TITLE
docs: map full stack and env setup links in README E2E flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,43 +2,49 @@
 # Copy this file to .env locally. Never commit real credentials.
 #
 # Source of truth for every value and where to obtain it:
-# docs/user-guide/env-vars.md
+#   docs/user-guide/env-vars.md
 # Setup order and commands:
-# docs/user-guide/setup-commands.md
-# Dedicated platform setup:
-# docs/user-guide/supabase-setup.md and docs/user-guide/modal-setup.md
+#   docs/user-guide/setup-commands.md
+# Dedicated platform / router setup:
+#   docs/user-guide/supabase-setup.md
+#   docs/user-guide/modal-setup.md
+#   docs/user-guide/sie-setup.md
+#   docs/user-guide/model-studio-setup.md
+# End-to-end flow (when each stack is used):
+#   README.md → “Run your first Live scan” / “What happens next”
+#   QUICKSTART.md → First Live scan
 
-# Modal non-interactive authentication. See docs/user-guide/modal-setup.md.
+# --- Platform: Modal (scan sandbox) --- docs/user-guide/modal-setup.md
 MODAL_TOKEN_ID=
 MODAL_TOKEN_SECRET=
 
-# Supabase project values. See docs/user-guide/supabase-setup.md.
+# --- Platform: Supabase (store + Live dashboard) --- docs/user-guide/supabase-setup.md
 SUPABASE_ANON_KEY=
 SUPABASE_URL=
 SUPABASE_SERVICE_ROLE_KEY=
 SUPABASE_DB_URL=
 
-# Snyk scanner credentials. See docs/user-guide/env-vars.md.
+# --- Scanner: Snyk --- docs/user-guide/env-vars.md#vendor-procurement-quick-steps
 SNYK_TOKEN=
 
-# Cisco Skill Scanner LLM credentials. See docs/user-guide/env-vars.md.
+# --- Scanner: Cisco Skill Scanner LLM --- docs/user-guide/env-vars.md#vendor-procurement-quick-steps
 SKILL_SCANNER_LLM_API_KEY=
 # SKILL_SCANNER_LLM_API_VERSION=
 SKILL_SCANNER_LLM_MODEL=
 SKILL_SCANNER_LLM_PROVIDER=
 SKILL_SCANNER_LLM_BASE_URL=
 
-# Cisco MCP Scanner LLM credentials. See docs/user-guide/env-vars.md.
+# --- Scanner: Cisco MCP Scanner LLM --- docs/user-guide/env-vars.md#vendor-procurement-quick-steps
 MCP_SCANNER_LLM_API_KEY=
 # MCP_SCANNER_LLM_API_VERSION=
 MCP_SCANNER_LLM_MODEL=
 MCP_SCANNER_LLM_BASE_URL=
 
-# Tessl scanner credentials. See docs/user-guide/env-vars.md.
+# --- Scanner: Tessl --- docs/user-guide/env-vars.md#vendor-procurement-quick-steps
 TESSL_TOKEN=
 # TESSL_WORKSPACE=
 
-# Cisco AI Defense and MCP Scanner credentials. See docs/user-guide/env-vars.md.
+# --- Scanner: Cisco AI Defense / MCP cloud inspect --- docs/user-guide/env-vars.md#vendor-procurement-quick-steps
 AI_DEFENSE_API_KEY=
 # AI_DEFENSE_API_URL=
 MCP_SCANNER_API_KEY=
@@ -47,7 +53,8 @@ MCP_SCANNER_ENDPOINT=https://us.api.inspect.aidefense.security.cisco.com/api/v1
 # Modal scanner-secret allowlist and manual fallback:
 # fixtures/OPTIONAL_SCANNER_KEYS.md
 
-# Optional tiered router (SIE + Model Studio). See docs/user-guide/env-vars.md.
+# --- Optional router: Alibaba Cloud Model Studio (escalation) ---
+# docs/user-guide/model-studio-setup.md · docs/user-guide/env-vars.md
 # Not required for scanner Live coverage; auto-route warns and skips if unset.
 DASHSCOPE_API_KEY=""
 DASHSCOPE_HOST=""
@@ -55,7 +62,8 @@ ALIBABA_OPENAI_BASE_URL=""
 ALIBABA_DASH_SCOPE_API_URL=""
 MODEL_STUDIO_MODEL=""
 
-# Superlinked SIE (tripwire route + prototypes/sie-studio)
+# --- Optional router: Superlinked SIE (tripwire route + prototypes/sie-studio) ---
+# docs/user-guide/sie-setup.md · docs/user-guide/env-vars.md
 SIE_MODEL=""
 SIE_ENDPOINT=""
 SIE_API_KEY=""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - README “What happens next” / “Find the right guide” now map the full stack
   (Discover→Scan→Store→Route→Review) and older setup guides (prerequisites,
   path-commands, Supabase, Modal, env-vars, screenshots, SECURITY)
+- `.env.example` annotates each key group with its stack setup doc; E2E flow
+  table links setup per hop; Cisco Skill/MCP LLM procurement clarified in
+  `env-vars.md`
 - Screenshot gallery refreshed: CLI help includes `route`, live Modal scan
   capture updated, dashboard/skill/MCP shots retaken from Mock demo data,
   Escalated / SIE-only / pathway filter shots; regenerate UI shots with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (wired from README, QUICKSTART, docs index, env-vars, prerequisites)
 - Operator howto for pathway strips / Escalated / SIE-only / categories:
   `docs/user-guide/reading-router-results.md`
+- README “What happens next” / “Find the right guide” now map the full stack
+  (Discover→Scan→Store→Route→Review) and older setup guides (prerequisites,
+  path-commands, Supabase, Modal, env-vars, screenshots, SECURITY)
 - Screenshot gallery refreshed: CLI help includes `route`, live Modal scan
   capture updated, dashboard/skill/MCP shots retaken from Mock demo data,
   Escalated / SIE-only / pathway filter shots; regenerate UI shots with

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -46,13 +46,16 @@ findings until the platform accounts, `.env`, schema, and Modal app are ready.
 
 ## Shared setup reference
 
+- [Prerequisites](docs/user-guide/prerequisites.md)
+- [Path commands (Install → Live)](docs/user-guide/path-commands.md)
 - [Setup command catalog](docs/user-guide/setup-commands.md)
-- [Operational path (Install → Local validation → Live)](docs/user-guide/path-commands.md)
 - [Supabase setup](docs/user-guide/supabase-setup.md)
 - [Modal setup](docs/user-guide/modal-setup.md)
 - [SIE setup](docs/user-guide/sie-setup.md) (optional router)
 - [Model Studio setup](docs/user-guide/model-studio-setup.md) (optional escalation)
+- [Reading router results](docs/user-guide/reading-router-results.md)
 - [Environment keys](docs/user-guide/env-vars.md)
+- [Screenshot gallery](docs/screenshots/README.md)
 
 ## Daily workflow
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -112,10 +112,12 @@ Values for full five-vendor scan coverage:
 - `MCP_SCANNER_ENDPOINT` (default is prefilled if you keep Cisco endpoint default)
 
 Optional for tiered routing ([sie-setup](docs/user-guide/sie-setup.md),
-[model-studio-setup](docs/user-guide/model-studio-setup.md)):
+[model-studio-setup](docs/user-guide/model-studio-setup.md),
+[env-vars § router](docs/user-guide/env-vars.md#optional--tiered-router-sie--model-studio)):
 
 - `SIE_ENDPOINT`, `SIE_API_KEY` (and optionally `SIE_MODEL`)
 - `DASHSCOPE_API_KEY`, `ALIBABA_OPENAI_BASE_URL` (and optionally `MODEL_STUDIO_MODEL`, `DASHSCOPE_HOST`)
+- `ALIBABA_DASH_SCOPE_API_URL` — sample CLI image/video only; not required by `tripwire route`
 
 Then run bootstrap:
 

--- a/README.md
+++ b/README.md
@@ -77,12 +77,14 @@ explain each decision before you make it.
 
 1. Check the required tools and [install the CLI](docs/user-guide/setup-commands.md#repository-and-cli-bootstrap).
 2. Create the accounts you need: [Supabase](docs/user-guide/supabase-setup.md),
-   [Modal](docs/user-guide/modal-setup.md), then add Snyk, Tessl, and Cisco credentials
-   with the [environment-variable procurement guide](docs/user-guide/env-vars.md#vendor-procurement-quick-steps).
+   [Modal](docs/user-guide/modal-setup.md), then add Snyk, Tessl, and Cisco
+   (Skill/MCP LLM + optional AI Defense) credentials with the
+   [environment-variable procurement guide](docs/user-guide/env-vars.md#vendor-procurement-quick-steps).
    For optional post-scan routing ([ADR-0016](docs/adr/0016-tiered-router-sie-model-studio.md)),
    also set up [Superlinked SIE](docs/user-guide/sie-setup.md) (required for routing)
    and optionally [Alibaba Cloud Model Studio](docs/user-guide/model-studio-setup.md)
-   (escalation only).
+   (escalation only). Key map for every `.env` name: [env-vars.md](docs/user-guide/env-vars.md)
+   (mirrors [`.env.example`](.env.example)).
 3. Create `.env` only after you have the values, then fill it with
    [env-vars.md](docs/user-guide/env-vars.md) as the single key reference.
 4. Bootstrap Supabase and deploy the Modal scan app with the
@@ -123,13 +125,13 @@ tripwire scan --dry-discover ./fixtures/skills/safe-csv-cleaner
 Tripwire’s Live path is a short pipeline. Each hop uses a concrete piece of the
 stack (same names as the badges above):
 
-| Step | What runs | Stack |
-|---|---|---|
-| Discover | CLI finds skills / MCP servers (`tripwire scan --dry-discover` or a real scan) | Node.js CLI |
-| Scan | Adapters run in an isolated sandbox | Modal (+ Docker image), Python sandbox, Cisco / Snyk / Tessl |
-| Store | Findings and scan_run rows land for the dashboard | Supabase / Postgres |
-| Route (optional) | Every item through SIE; escalate only when signaled | Superlinked SIE → Alibaba Cloud Model Studio via `tripwire route` / auto-route |
-| Review | Heatmap, drawers, pathway strips, Escalated / SIE-only filters | Dashboard (Live or Mock) |
+| Step | What runs | Stack | Setup |
+|---|---|---|---|
+| Discover | CLI finds skills / MCP servers (`tripwire scan --dry-discover` or a real scan) | Node.js CLI | [setup-commands](docs/user-guide/setup-commands.md#repository-and-cli-bootstrap) |
+| Scan | Adapters run in an isolated sandbox | Modal (+ Docker image), Python sandbox, Cisco / Snyk / Tessl | [modal-setup](docs/user-guide/modal-setup.md) · [env-vars](docs/user-guide/env-vars.md) (Snyk / Tessl / Cisco) |
+| Store | Findings and scan_run rows land for the dashboard | Supabase / Postgres | [supabase-setup](docs/user-guide/supabase-setup.md) |
+| Route (optional) | Every item through SIE; escalate only when signaled | Superlinked SIE → Alibaba Cloud Model Studio via `tripwire route` / auto-route | [sie-setup](docs/user-guide/sie-setup.md) · [model-studio-setup](docs/user-guide/model-studio-setup.md) · [env-vars § router](docs/user-guide/env-vars.md#optional--tiered-router-sie--model-studio) |
+| Review | Heatmap, drawers, pathway strips, Escalated / SIE-only filters | Dashboard (Live or Mock) | [reading-router-results](docs/user-guide/reading-router-results.md) · [screenshots](docs/screenshots/README.md) |
 
 Mock skips Discover→Scan→Store and still shows Review (plus router fixtures).
 Without SIE keys, Route warns and skips; scanner results still store. Sample CLIs

--- a/README.md
+++ b/README.md
@@ -120,70 +120,89 @@ tripwire scan --dry-discover ./fixtures/skills/safe-csv-cleaner
 
 ## What happens next
 
-The workflow is deliberately small: discover the target, scan it with the enabled
-adapters, optionally route findings through Superlinked SIE (and Model Studio on
-escalation) via auto-route or `tripwire route --batch-id …`, then review the result.
-Mock lets you explore the final step safely; Live uses Supabase, Modal, and the
-configured Snyk, Tessl, and Cisco scanners for real scans.
+Tripwire’s Live path is a short pipeline. Each hop uses a concrete piece of the
+stack (same names as the badges above):
 
-### Optional: iterate on router backends locally
+| Step | What runs | Stack |
+|---|---|---|
+| Discover | CLI finds skills / MCP servers (`tripwire scan --dry-discover` or a real scan) | Node.js CLI |
+| Scan | Adapters run in an isolated sandbox | Modal (+ Docker image), Python sandbox, Cisco / Snyk / Tessl |
+| Store | Findings and scan_run rows land for the dashboard | Supabase / Postgres |
+| Route (optional) | Every item through SIE; escalate only when signaled | Superlinked SIE → Alibaba Cloud Model Studio via `tripwire route` / auto-route |
+| Review | Heatmap, drawers, pathway strips, Escalated / SIE-only filters | Dashboard (Live or Mock) |
 
-For research or smoke-testing SIE / Model Studio without a full scan batch, sample
-CLIs live under [`prototypes/sie-studio/`](prototypes/sie-studio/README.md) and
-[`prototypes/model-studio/`](prototypes/model-studio/README.md) (same env keys as
-the product router).
+Mock skips Discover→Scan→Store and still shows Review (plus router fixtures).
+Without SIE keys, Route warns and skips; scanner results still store. Sample CLIs
+for router backends (no full batch): [`prototypes/sie-studio/`](prototypes/sie-studio/README.md),
+[`prototypes/model-studio/`](prototypes/model-studio/README.md).
 
 ```mermaid
 flowchart LR
-    discover[Discover skills and MCP servers] --> scan[Scan enabled targets]
-    scan --> route[Optional SIE / Model Studio route]
-    route --> review[Review findings in the dashboard]
+  discover["Discover<br/>Node CLI"] --> scan["Scan<br/>Modal + Cisco/Snyk/Tessl"]
+  scan --> store["Store<br/>Supabase"]
+  store --> route["Route optional<br/>SIE → Model Studio"]
+  route --> review["Review<br/>Dashboard"]
 ```
+
+How to read strips and filters after Route:
+[reading-router-results.md](docs/user-guide/reading-router-results.md).
+
 ### Screenshots
 
 <table>
 <tr>
-  <td align="center" width="25%">
+  <td align="center" width="20%">
     <a href="docs/screenshots/01-cli/02-cli-real-scan-modal-sandbox.png">
       <img src="docs/screenshots/01-cli/02-cli-real-scan-modal-sandbox.png" width="100%" alt="CLI — real scan with Modal sandbox output">
     </a>
-    <sub><b>CLI scan</b> — Modal sandbox (live)</sub>
+    <sub><b>CLI scan</b> — Modal (live)</sub>
   </td>
-  <td align="center" width="25%">
+  <td align="center" width="20%">
     <a href="docs/screenshots/02-dashboard/02-dashboard-overview-grid.png">
       <img src="docs/screenshots/02-dashboard/02-dashboard-overview-grid.png" width="100%" alt="Dashboard overview grid (Mock demo data)">
     </a>
     <sub><b>Dashboard</b> — Mock overview</sub>
   </td>
-  <td align="center" width="25%">
+  <td align="center" width="20%">
+    <a href="docs/screenshots/02-dashboard/14-filter-escalated.png">
+      <img src="docs/screenshots/02-dashboard/14-filter-escalated.png" width="100%" alt="Dashboard Escalated filter (Mock)">
+    </a>
+    <sub><b>Router</b> — Escalated (Mock)</sub>
+  </td>
+  <td align="center" width="20%">
     <a href="docs/screenshots/03-skills/04-red-skill-detail-vuln-prompt-injection.png">
       <img src="docs/screenshots/03-skills/04-red-skill-detail-vuln-prompt-injection.png" width="100%" alt="Skill detail — prompt injection finding (Mock)">
     </a>
-    <sub><b>Skill finding</b> — Red (Mock)</sub>
+    <sub><b>Skill</b> — Red (Mock)</sub>
   </td>
-  <td align="center" width="25%">
+  <td align="center" width="20%">
     <a href="docs/screenshots/04-mcp-servers/10-red-mcp-detail-vuln-command-injection.png">
       <img src="docs/screenshots/04-mcp-servers/10-red-mcp-detail-vuln-command-injection.png" width="100%" alt="MCP server detail — command injection finding (Mock)">
     </a>
-    <sub><b>MCP finding</b> — Red (Mock)</sub>
+    <sub><b>MCP</b> — Red (Mock)</sub>
   </td>
 </tr>
 </table>
 
-> Full gallery with all severity levels and surfaces → [docs/screenshots/](docs/screenshots/README.md)
+> Full gallery (SIE-only, severity filters, list view) → [docs/screenshots/](docs/screenshots/README.md)
 
 ## Find the right guide
 
 | Your task | Start here |
 |---|---|
-| Run your first Live scan | [Follow the Quickstart](QUICKSTART.md#first-live-scan) |
-| Preview the dashboard or validate locally | [Optional local validation](QUICKSTART.md#validate-locally-optional) |
-| Enable optional SIE / Model Studio routing | [SIE setup](docs/user-guide/sie-setup.md) · [Model Studio setup](docs/user-guide/model-studio-setup.md) · [`tripwire route`](docs/user-guide/setup-commands.md#tiered-router-optional) |
+| Check tools and technical fit | [Prerequisites](docs/user-guide/prerequisites.md) |
+| Follow the Install → Live path map | [Path commands](docs/user-guide/path-commands.md) · [onboarding cheatsheet](docs/user-guide/onboarding-cheatsheet.md) |
+| Create the Supabase project | [Supabase setup](docs/user-guide/supabase-setup.md) |
+| Deploy the Modal scan app | [Modal setup](docs/user-guide/modal-setup.md) |
+| Procure scanner and router `.env` keys | [Environment variables](docs/user-guide/env-vars.md) |
+| Run your first Live scan | [Quickstart](QUICKSTART.md#first-live-scan) · [setup commands](docs/user-guide/setup-commands.md) |
+| Preview Mock UI or dry-discover locally | [Optional local validation](QUICKSTART.md#validate-locally-optional) |
+| Enable SIE / Model Studio routing | [SIE setup](docs/user-guide/sie-setup.md) · [Model Studio setup](docs/user-guide/model-studio-setup.md) · [`tripwire route`](docs/user-guide/setup-commands.md#tiered-router-optional) |
 | Interpret pathway strips / Escalated / SIE-only | [Reading router results](docs/user-guide/reading-router-results.md) |
-| Understand results and system shape | [Capability status](docs/STATUS.md) · [Architecture](docs/ARCHITECTURE.md) · [Decisions](docs/adr/README.md) |
-| Contribute or maintain the project | [Contributing](CONTRIBUTING.md) · [command catalog](docs/user-guide/setup-commands.md) |
+| Browse CLI / dashboard screenshots | [Screenshot gallery](docs/screenshots/README.md) |
+| Smoke-test SIE or Model Studio alone | [SIE sample CLI](prototypes/sie-studio/README.md) · [Model Studio sample CLI](prototypes/model-studio/README.md) |
+| Understand results and system shape | [Capability status](docs/STATUS.md) · [Architecture](docs/ARCHITECTURE.md) · [ADRs](docs/adr/README.md) |
+| Contribute or maintain | [Contributing](CONTRIBUTING.md) · [command catalog](docs/user-guide/setup-commands.md) |
+| Report a vulnerability | [SECURITY](SECURITY.md) |
 
-For the full documentation map, see [docs/README.md](docs/README.md). The
-[prerequisites](docs/user-guide/prerequisites.md), [environment-variable guide](docs/user-guide/env-vars.md),
-and [setup command catalog](docs/user-guide/setup-commands.md) hold the detailed setup
-and maintenance instructions.
+Full map (including planning / CI): [docs/README.md](docs/README.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,11 +10,15 @@ Use this map to move from a safe first look to the level of setup or project det
 
 | Your task | Start here | Then |
 |---|---|---|
-| Run a first Live scan | [Quickstart: ordered Live setup](../QUICKSTART.md#first-live-scan) | [Supabase setup](./user-guide/supabase-setup.md) → [Modal setup](./user-guide/modal-setup.md) → [environment keys](./user-guide/env-vars.md) → [scan and dashboard](../QUICKSTART.md#live-capabilities) |
+| Check tools and fit | [Prerequisites](./user-guide/prerequisites.md) | [Path commands](./user-guide/path-commands.md) · [onboarding cheatsheet](./user-guide/onboarding-cheatsheet.md) |
+| Create Supabase / deploy Modal | [Supabase setup](./user-guide/supabase-setup.md) | [Modal setup](./user-guide/modal-setup.md) → [environment keys](./user-guide/env-vars.md) |
+| Run a first Live scan | [Quickstart: ordered Live setup](../QUICKSTART.md#first-live-scan) | [Setup commands](./user-guide/setup-commands.md) → [scan and dashboard](../QUICKSTART.md#live-capabilities) |
 | Enable optional tiered routing | [SIE setup](./user-guide/sie-setup.md) | [Model Studio setup](./user-guide/model-studio-setup.md) → [`tripwire route`](./user-guide/setup-commands.md#tiered-router-optional) → [read router results](./user-guide/reading-router-results.md) |
-| Preview or validate locally | [Optional local validation](../QUICKSTART.md#validate-locally-optional) | [README: dashboard preview](../README.md#preview-the-dashboard-optional) |
+| Preview or validate locally | [Optional local validation](../QUICKSTART.md#validate-locally-optional) | [README: dashboard preview](../README.md#preview-the-dashboard-optional) · [screenshots](./screenshots/README.md) |
+| Smoke-test SIE / Model Studio alone | [SIE sample CLI](../prototypes/sie-studio/README.md) | [Model Studio sample CLI](../prototypes/model-studio/README.md) |
 | Understand results and system shape | [Capability status](./STATUS.md) | [Architecture](./ARCHITECTURE.md) · [ADRs](./adr/README.md) · [router UI](./user-guide/reading-router-results.md) |
 | Contribute or maintain | [Contributing](../CONTRIBUTING.md) | [Setup and maintenance commands](./user-guide/setup-commands.md) |
+| Report a vulnerability | [SECURITY](../SECURITY.md) | — |
 
 ## Setup and operation
 

--- a/docs/user-guide/env-vars.md
+++ b/docs/user-guide/env-vars.md
@@ -110,9 +110,13 @@ secret-creation command.
   4. If you only use interactive setup, skip both values and keep them blank.
 - **Snyk:** open [app.snyk.io](https://app.snyk.io) → Settings → API Tokens and create/copy a token for `SNYK_TOKEN`.
 - **Tessl:** open [tessl.io](https://tessl.io), create/login; use Tessl UI token page or `tessl api-key create --workspace <name>` for `TESSL_TOKEN`, and set `TESSL_WORKSPACE`.
-- **Cisco AI Defense:** open [Cisco Developer](https://developer.cisco.com) and locate AI Defense credentials for:
-  - `AI_DEFENSE_API_KEY`
+- **Cisco Skill / MCP Scanner LLM (Tier B):** provision an OpenAI-compatible (or Azure) LLM for the Cisco Skill and MCP scanner CLIs. Map into:
+  - Skill: `SKILL_SCANNER_LLM_API_KEY`, `SKILL_SCANNER_LLM_MODEL`, `SKILL_SCANNER_LLM_PROVIDER`, `SKILL_SCANNER_LLM_BASE_URL` (optional `SKILL_SCANNER_LLM_API_VERSION`)
+  - MCP: `MCP_SCANNER_LLM_API_KEY`, `MCP_SCANNER_LLM_MODEL`, `MCP_SCANNER_LLM_BASE_URL` (optional `MCP_SCANNER_LLM_API_VERSION`)
+  These are **not** the same as AI Defense cloud inspect keys below; without them Skill/MCP LLM depth is skipped.
+- **Cisco AI Defense (Tier C — paid cloud inspect):** open [Cisco Developer](https://developer.cisco.com) and locate AI Defense credentials for:
+  - `AI_DEFENSE_API_KEY` (and optionally `AI_DEFENSE_API_URL`)
   - `MCP_SCANNER_API_KEY`
   and optionally set `MCP_SCANNER_ENDPOINT` only for non-default hosts.
-- **Superlinked SIE (optional router):** [sie-setup](./sie-setup.md)
-- **Alibaba Cloud Model Studio (optional router escalation):** [model-studio-setup](./model-studio-setup.md)
+- **Superlinked SIE (optional router):** [sie-setup](./sie-setup.md) — `SIE_ENDPOINT`, `SIE_API_KEY`, optional `SIE_MODEL`.
+- **Alibaba Cloud Model Studio (optional router escalation):** [model-studio-setup](./model-studio-setup.md) — `DASHSCOPE_API_KEY`, `ALIBABA_OPENAI_BASE_URL`, optional `DASHSCOPE_HOST` / `MODEL_STUDIO_MODEL` / `ALIBABA_DASH_SCOPE_API_URL` (sample CLI image/video only).

--- a/docs/user-guide/path-commands.md
+++ b/docs/user-guide/path-commands.md
@@ -25,13 +25,15 @@ for the product validation journey.
 
 ## 4) Enable Live capabilities
 
-Follow all five vendor paths for full scan coverage, populate `.env`, and run the platform commands from
+Follow all five scanner-platform vendor paths for full scan coverage (Supabase,
+Modal, Snyk, Tessl, Cisco), populate `.env`, and run the platform commands from
 [Live environment bootstrap](./setup-commands.md#3-live-environment-bootstrap).
 Use [env-vars.md](./env-vars.md) for accounts, keys, and capability mapping; use
 [OPTIONAL_SCANNER_KEYS.md](../../fixtures/OPTIONAL_SCANNER_KEYS.md) only for the
 Modal scanner-secret projection and helper-only synchronization behavior.
 Optional tiered routing: [sie-setup.md](./sie-setup.md) then
-[model-studio-setup.md](./model-studio-setup.md).
+[model-studio-setup.md](./model-studio-setup.md); interpret UI with
+[reading-router-results.md](./reading-router-results.md).
 
 ## 5) Maintain or contribute
 

--- a/prototypes/.env.example
+++ b/prototypes/.env.example
@@ -2,6 +2,7 @@
 # Never commit real keys.
 #
 # --- Alibaba Cloud Model Studio (prototypes/model-studio) ---
+# Setup: ../../docs/user-guide/model-studio-setup.md
 # If ALIBABA_* URLs are left blank, model_studio.py generates them from DASHSCOPE_HOST:
 #   OpenAI:    https://$DASHSCOPE_HOST/compatible-mode/v1
 #   DashScope: https://$DASHSCOPE_HOST/api/v1
@@ -13,10 +14,18 @@ ALIBABA_OPENAI_BASE_URL=https://ws-217y1bpliyzcf5nl.ap-southeast-1.maas.aliyuncs
 ALIBABA_DASH_SCOPE_API_URL=https://ws-217y1bpliyzcf5nl.ap-southeast-1.maas.aliyuncs.com/api/v1
 
 # --- Superlinked SIE managed cloud (prototypes/sie-studio + tripwire route) ---
+# Setup: ../../docs/user-guide/sie-setup.md
 # Region us-east-2 → https://api.superlinked.com
 # EU → https://eu.api.superlinked.com
 # Key from console.superlinked.com (Keys page); looks like sk-sie-...
 # Also copy SIE_* / DASHSCOPE_* / ALIBABA_* into repo-root .env for the CLI router.
+# Optional: SIE_MODEL=gen-4b (default)
 
 SIE_ENDPOINT=https://api.superlinked.com
 SIE_API_KEY=
+# SIE_MODEL=
+
+# --- Alibaba Cloud Model Studio extras for sample CLI ---
+# Setup: ../../docs/user-guide/model-studio-setup.md
+# Optional: MODEL_STUDIO_MODEL=qwen3.8-max (default for tripwire route)
+# MODEL_STUDIO_MODEL=


### PR DESCRIPTION
## Summary

- Expand README **What happens next** and **Find the right guide** so Discover→Scan→Store→Route→Review names the full stack, and older setup guides (prerequisites, path-commands, Supabase, Modal, env-vars, screenshots, SECURITY) plus router howtos are discoverable from the entrypoint.
- Annotate `.env.example` (and `prototypes/.env.example`) per platform/scanner/router with setup-doc pointers; add a **Setup** column to the README pipeline table; clarify Cisco Skill/MCP LLM vs AI Defense procurement in `env-vars.md`; note `ALIBABA_DASH_SCOPE_API_URL` in QUICKSTART.
- Align `docs/README.md` Choose a task and QUICKSTART shared setup references.

## Test Results

| Stack | Result | Coverage |
|-------|--------|----------|
| Python (`sandbox/tests`) | 130 passed | 96.43% lines (gate ≥95%) |
| Node CLI (`cli`) | 67 passed | 95.55% stmts / 82.87% branches / 96.29% funcs / 95.55% lines |
| Dashboard (`prototypes/dc-dashboard`) | 58 passed, 1 skipped | 98.38% stmts / 86.97% branches / 96.55% funcs / 98.38% lines |

## Quality Gates

| Check | Result |
|-------|--------|
| markdownlint / shellcheck / actionlint (`--quick`) | pass |
| ruff check + format | pass |
| mypy | pass |
| bandit / vulture / gitleaks | pass |
| xenon (Python average) | average complexity ranked **B** (unchanged serious-tier signal; docs-only PR) |

## Checklist

- [x] `./scripts/quality-gates.sh` passes locally
- [x] New tests added or updated (or change is docs-only)
- [x] Docs updated where applicable
- [x] No secrets or credentials committed