### PR TITLE
feat(guard): gate Bash/MCP skill paths and harden agent-hooks flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,8 +203,13 @@ jobs:
       - name: OSV-Scanner (SCA)
         uses: google/osv-scanner-action/osv-scanner-action@v2.3.8
         with:
+          # Exclude intentional vuln fixtures / prototypes (parity with Trivy skip-dirs).
+          # Fixture-local osv-scanner.toml also ignores vuln-dependency-lodash.
           scan-args: |-
             --recursive
+            --experimental-exclude=fixtures
+            --experimental-exclude=prototypes
+            --experimental-exclude=internal-docs
             .
 
   meterian:

--- a/agent-hooks/hooks/pre-tool-use.sh
+++ b/agent-hooks/hooks/pre-tool-use.sh
@@ -103,6 +103,45 @@ STDIN_FILE="$(mktemp "${TMPDIR:-/tmp}/tripwire-hook-stdin.XXXXXX")"
 OUT_FILE="$(mktemp "${TMPDIR:-/tmp}/tripwire-hook-out.XXXXXX")"
 cat > "$STDIN_FILE"
 
+# ── 2b. Fast-path ordinary Bash (no skills-path touch) ───────────────────────
+#      Matcher includes Bash so …/skills/<name>/install.sh is gated, but most
+#      Bash calls are unrelated. Skip the uv/Supabase path when neither the
+#      command nor the payload cwd references a skills locus.
+BASH_FAST="$(python3 -c '
+import json, os, sys
+
+with open(sys.argv[1], encoding="utf-8") as f:
+    payload = json.load(f)
+if not isinstance(payload, dict):
+    print("check")
+    raise SystemExit(0)
+if (payload.get("tool_name") or "") != "Bash":
+    print("check")
+    raise SystemExit(0)
+tool_input = payload.get("tool_input")
+cmd = ""
+if isinstance(tool_input, dict) and isinstance(tool_input.get("command"), str):
+    cmd = tool_input["command"]
+cwd = payload.get("cwd") if isinstance(payload.get("cwd"), str) else ""
+home_skills = os.path.join(os.path.expanduser("~"), ".claude", "skills")
+markers = (
+    "/.claude/skills/",
+    "/.claude/skills",
+    "~/.claude/skills",
+    home_skills,
+)
+blob = cmd + "\n" + cwd
+if any(m in blob for m in markers):
+    print("check")
+else:
+    print("allow")
+' "$STDIN_FILE" 2>/dev/null)" || BASH_FAST="check"
+
+if [ "$BASH_FAST" = "allow" ]; then
+  emit_allow
+  exit 0
+fi
+
 "$UV_BIN" run --project "$CFG_REPO_ROOT" --extra guard python "$ENTRY_SHIM" \
   < "$STDIN_FILE" > "$OUT_FILE" &
 DELEGATE_PID=$!

--- a/agent-hooks/skills/tw-disable/SKILL.md
+++ b/agent-hooks/skills/tw-disable/SKILL.md
@@ -7,6 +7,12 @@ description: Turn Tripwire enforcement OFF for Claude Code tool calls. Use when 
 
 Flip the local Tripwire kill switch OFF. This edits ONLY the `enable` key of `~/.tripwire/config.json` — no Supabase writes, no other keys touched.
 
+## Step 0 — Ask before disabling
+
+**Stop and ask the user:** *Do you want to turn Tripwire enforcement OFF?*
+
+**Do not proceed to Step 1 until the user explicitly confirms.** If they decline or are unsure, stop with no config change.
+
 ## Step 1 — Set enable=false (python3 JSON round-trip)
 
 Run exactly this (do not hand-edit the file with text tools):

--- a/agent-hooks/skills/tw-enable/SKILL.md
+++ b/agent-hooks/skills/tw-enable/SKILL.md
@@ -7,6 +7,12 @@ description: Turn Tripwire enforcement ON for Claude Code tool calls. Use when t
 
 Flip the local Tripwire kill switch ON. This edits ONLY the `enable` key of `~/.tripwire/config.json` — no Supabase writes, no other keys touched.
 
+## Step 0 — Ask before enabling
+
+**Stop and ask the user:** *Do you want to turn Tripwire enforcement ON?*
+
+**Do not proceed to Step 1 until the user explicitly confirms.** If they decline or are unsure, stop with no config change.
+
 ## Step 1 — Set enable=true (python3 JSON round-trip)
 
 Run exactly this (do not hand-edit the file with text tools):

--- a/agent-hooks/skills/tw-scan/SKILL.md
+++ b/agent-hooks/skills/tw-scan/SKILL.md
@@ -5,7 +5,9 @@ description: Submit Claude Code skills and MCP servers to Tripwire for security 
 
 # tw-scan
 
-Resolve names to artifacts and submit them to the Tripwire scanner. Single pass over ALL requested names — never stop at the first problem; every requested name gets a row in both outputs.
+Resolve names to artifacts and submit them to the Tripwire scanner. Single pass over ALL requested names — never stop at the first problem; every requested name gets a row in the report table. Do **not** dump the driver's raw JSON, the CLI result JSON, or any fenced `{config, artifacts}` block to the user — those payloads are for you to parse only.
+
+**Hard rule — scanning ≠ executing.** Submitting a scan does **not** authorize running the artifact. After submit, artifacts stay blocked (`scanning` / prior verdict) until a completed green-below-threshold verdict exists. Never invoke `Skill` / `mcp__*` / skill `install.sh` for still-blocked targets in the same session “to try them now.”
 
 ## Step 1 — Parse arguments
 
@@ -15,27 +17,36 @@ Names are space- OR comma-separated. **Force**: both syntaxes work — a literal
 
 Read `~/.tripwire/config.json`: `scan_validity_days`, `repo_root`, `cli_bin`, `env_file`, `uv_bin`. If missing/unparseable, tell the user config is missing/corrupt and `tripwire setup-agent-hooks` restores it — then stop (submission needs `cli_bin`/`repo_root`).
 
-## Step 3 — Resolve each name to an artifact (shared resolution procedure)
+## Step 3 — Resolve each name (deterministic — do NOT hand-search loci)
 
-For EACH requested name, search these candidate loci:
+**Hard rule:** never browse skills/MCP loci yourself to decide NOT FOUND. Always run this resolve driver once with every requested name (same helper the PreToolUse hook uses, plus demo fixture aliases):
 
-- **Skills — user scope**: every directory under `~/.claude/skills/`. A directory matches if its basename equals the name OR its `SKILL.md` frontmatter `name:` equals the name (they can differ — check both).
-- **Skills — project scope**: every directory under `./.claude/skills/`, same matching rule.
-- **MCP servers**: config keys, searched in the same order as the enforcement hook: `./.mcp.json` (project scope), `~/.claude.json` (user scope — BOTH the top-level `mcpServers` object AND `projects["<cwd>"].mcpServers`), `~/.tripwire/demo-mcp.json` (demo manifest), `<repo_root>/fixtures/mcp/mcp_manifest.json` (fixtures manifest; `repo_root` from config). A key matches if it equals the name. Config-key resolution only — never derive a directory or path from the entry's `command`/`args`.
+```bash
+cd "<repo_root>" && set -a && source "<env_file>" && set +a && "<uv_bin>" run --extra guard python -c '
+import json, os, sys
+from guard.entry import resolve_operator_name
+cwd = os.getcwd()
+out = []
+for name in sys.argv[1:]:
+    r = resolve_operator_name(name, cwd)
+    if r is None:
+        out.append({"name": name, "found": False})
+    else:
+        out.append({"name": name, "found": True, **r})
+print(json.dumps({"resolutions": out}))
+' <name-1> <name-2> ...
+```
 
-Canonicalize:
+Parse privately:
 
-- Skill match → identifier = **canonical absolute path** of the skill directory (`realpath`, symlinks resolved, no trailing slash).
-- MCP match → identifier = **the config key string itself, always** (key-only identity: an MCP server's identity is its config key, never a path derived from `command`/`args`). Known accepted consequence: the stored `content_hash` for MCP items is `pending:<key>`, so MCP verdicts carry no content binding, and same-named keys in different projects share one identity row — this matches the plan §5.4 manifest-only rule, now uniform for all MCP servers.
+- `found=false` → ❓ NOT FOUND row; tip that demo names are `safe-skill`/`vuln-skill`/`amber-skill` and `safe-tool`/`vuln-tool`/`amber-tool`.
+- `found=true` → use `identifier` + `kind` for later steps. Remember Step 5: MCP keys are submitted via a subset manifest file, never as bare CLI args.
 
-Outcomes per name:
-
-- **No match** → friendly per-name miss report (❓ NOT FOUND row): name, loci searched (`~/.claude/skills`, `./.claude/skills`, `./.mcp.json`, `~/.claude.json` (incl. `projects["<cwd>"]`), `~/.tripwire/demo-mcp.json`, `<repo_root>/fixtures/mcp/mcp_manifest.json`), and the tip that an explicit absolute path also works as a name here. A path the user passed directly that exists on disk is used as-is (realpath it).
-- **Multiple matches** → present the list (path + type) via AskUserQuestion, user picks one or more; each selection is its own row.
+An absolute path the user passed that exists as a skill directory is resolved by the driver.
 
 ## Step 4 — Check current status (skip-vs-submit)
 
-Run the status driver ONCE with all resolved identifiers (substitute `<repo_root>`, `<env_file>`, `<uv_bin>` from config; do not improvise queries):
+Run the status driver ONCE with all **found** identifiers (substitute `<repo_root>`, `<env_file>`, `<uv_bin>` from config; do not improvise queries):
 
 ```bash
 cd "<repo_root>" && set -a && source "<env_file>" && set +a && "<uv_bin>" run --extra guard python -c '
@@ -141,9 +152,9 @@ print(json.dumps(result))
 
 The result is `{"batch_id": ..., "scan_run_ids": [...], "failed_targets": [{"target", "error"}, ...]}`. Mapping run ids to artifacts: `scan_run_ids` lists run ids in the order the targets were passed on the command line — the subset manifest expands in place into one target per key (targets are the bare keys, in the manifest's key order) — minus any targets the CLI itself skipped (defensive: `--force` is always passed, so `[skip] <target> — content unchanged since last scan` lines should not occur) and minus failures that never got a run. Use the `[skip]` lines and `failed_targets` to attribute; if attribution is ambiguous, report the shared `batch_id` and say the per-run mapping is ambiguous rather than guessing.
 
-## Step 6 — Report (table first, then JSON, always both)
+## Step 6 — Report (table only)
 
-One row per requested name:
+One Markdown table, one row per requested name. Parse status-driver and CLI JSON privately; never paste them into the user-facing reply.
 
 | Name | Type | Action | Details |
 |------|------|--------|---------|
@@ -154,25 +165,6 @@ One row per requested name:
 | `broken-target` | mcp | ❌ FAILED | `<error from failed_targets>` |
 | `unknown-skill` | — | ❓ NOT FOUND | No match in ~/.claude/skills, .claude/skills, .mcp.json, ~/.claude.json, ~/.tripwire/demo-mcp.json, fixtures manifest |
 
-Then a fenced json block (§6.3 shape; scan rows add `batch_id`/`scan_run_id`):
+Row mapping: `submitted` → 🚀 SUBMITTED (include `batch_id` / `scan_run_id` in Details when known); `skipped` → ⏭️ SKIPPED; `skipped_by_cli` → ⏭️ SKIPPED (by CLI); `failed` → ❌ FAILED with the `failed_targets` error; `not_found` → ❓ NOT FOUND. Post-submission state for submitted rows is `scanning`.
 
-```json
-{
-  "config": { "enabled": true, "scan_validity_days": 14, "threshold": "red" },
-  "artifacts": [
-    {
-      "name": "new-skill",
-      "resolved_path": "/abs/path/to/skill",
-      "type": "skill",
-      "action": "submitted",
-      "state": "scanning",
-      "batch_id": "…",
-      "scan_run_id": "…",
-      "error": null,
-      "note": "scan submitted"
-    }
-  ]
-}
-```
-
-`action` is `submitted|skipped|skipped_by_cli|failed|not_found`; `state` is the post-submission state (`scanning` for submitted rows, the driver state otherwise, `not-found` for misses); `batch_id`/`scan_run_id` null when not submitted; `error` from `failed_targets` when failed. If anything failed, say plainly that those artifacts remain blocked until a scan completes green, and that the out-of-band remedy is `cd <repo_root> && node <cli_bin> scan <target> --no-defaults --force` in a terminal — where `<target>` is the skill's absolute path, or for an MCP server a manifest `.json` file containing that key (never the bare key, never a server directory).
+If anything failed, say plainly that those artifacts remain blocked until a scan completes green, and that the out-of-band remedy is `cd <repo_root> && node <cli_bin> scan <target> --no-defaults --force` in a terminal — where `<target>` is the skill's absolute path, or for an MCP server a manifest `.json` file containing that key (never the bare key, never a server directory).

--- a/agent-hooks/skills/tw-self-check/SKILL.md
+++ b/agent-hooks/skills/tw-self-check/SKILL.md
@@ -80,9 +80,9 @@ print(json.dumps({
 ' <identifier-1> <identifier-2> ...
 ```
 
-## Step 4 — Report (table first, then JSON, always both)
+## Step 4 — Report (Scan Status table only)
 
-Render exactly the tw-verify output format — same states, emoji, labels, and JSON shape (see `~/.claude/skills/tw-verify/SKILL.md` §Step 5–6). Summary of the row rules (N = `scan_validity_days`):
+Render exactly the tw-verify human table — same states, emoji, and labels (see `~/.claude/skills/tw-verify/SKILL.md` §Step 5). Parse the driver's JSON privately; do **not** dump a fenced `{config, artifacts}` block to the user. Summary of the row rules (N = `scan_validity_days`):
 
 - `fresh` + green → `🟢 GREEN (fresh)`, note `—`.
 - `fresh` + amber → `🟠 AMBER`; `Reported but not blocked at current threshold` when threshold is `red`, else bold **Will be blocked when Tripwire is enabled**.
@@ -91,9 +91,9 @@ Render exactly the tw-verify output format — same states, emoji, labels, and J
 - `scanning` → `⏳ SCANNING`; `Scan in progress — check back shortly` (+ prior verdict if rag non-null).
 - `unscanned` → `🚫 UNSCANNED`; `Never scanned — blocked when Tripwire is enabled` (or `Last scan errored — resubmit (run /tw-scan <name>)` when errored).
 - `changed=true` → `✏️ CHANGED`; bold **content changed since last scan — run /tw-scan <name>** — takes precedence over every state-based row (the hook's tamper deny fires regardless of a green verdict), `will_be_blocked` true.
-- missing install dir → `❓ NOT FOUND`; `Not installed under ~/.claude/skills — run tripwire setup-agent-hooks`.
+- missing install dir → `❓ NOT FOUND`; bold **Will be blocked when Tripwire is enabled** — `Not installed under ~/.claude/skills — run tripwire setup-agent-hooks`.
 
-Then the fenced json block (§6.3 shape: `config` + `artifacts` with `name`, `resolved_path`, `type: "skill"`, `state`, `rag` (fresh only, else null), `scanned_at`, `stale`, `changed`, `will_be_blocked`, `note`). If local `enable` is false, add the "currently bypassed" note; if `monitoring_enabled` is false, add the platform-switch warning.
+If local `enable` is false, add the "currently bypassed" note; if `monitoring_enabled` is false, add the platform-switch warning.
 
 A non-green result here matters: a blocked `tw-*` skill means the hook will block Tripwire's own tooling — the out-of-band remedies are `cd <repo_root> && node <cli_bin> scan <abs path> --no-defaults --force` in a terminal, or hand-editing `~/.tripwire/config.json` to `"enable": false`.
 

--- a/agent-hooks/skills/tw-verify/SKILL.md
+++ b/agent-hooks/skills/tw-verify/SKILL.md
@@ -5,7 +5,9 @@ description: Check the Tripwire scan status of Claude Code skills and MCP server
 
 # tw-verify
 
-Report the Tripwire scan status of one or more skills / MCP servers. Single pass over ALL requested names — never stop at the first problem; every requested name gets a row in both outputs. Read-only: this skill never submits scans itself (it only offers to, at the end).
+Report the Tripwire scan status of one or more skills / MCP servers. Single pass over ALL requested names — never stop at the first problem; every requested name gets a row in the Scan Status table. Read-only: this skill never submits scans itself (it only offers to, at the end). Do **not** dump the driver's raw JSON (or any fenced `{config, artifacts}` block) to the user — that payload is for you to parse only.
+
+**Hard rule — unscanned/blocked artifacts must not be executed.** If a row is `unscanned` (including errored), `stale`, `changed`, RED (or amber at threshold), or NOT FOUND: do **not** invoke that skill (`Skill` tool), do **not** call its `mcp__*` tools, and do **not** run its `install.sh` / scripts via Bash. Report that Tripwire will block those calls. Only offer `/tw-scan` via AskUserQuestion — never silently submit, and never “work around” a block by scanning so you can run the artifact in the same turn.
 
 ## Step 1 — Parse arguments
 
@@ -15,28 +17,36 @@ Names are space- OR comma-separated (e.g. `/tw-verify safe-skill, vuln-tool othe
 
 Read `~/.tripwire/config.json` (JSON). You need: `enable`, `scan_validity_days`, `repo_root`, `env_file`, `uv_bin` (and `cli_bin` if a scan is later requested). If the file is missing or unparseable, tell the user Tripwire config is missing/corrupt (the enforcement hook treats this as tampering and denies) and that `tripwire setup-agent-hooks` restores it — then stop; there is no way to query status without it.
 
-## Step 3 — Resolve each name to an artifact (shared resolution procedure)
+## Step 3 — Resolve each name (deterministic — do NOT hand-search loci)
 
-For EACH requested name, search these candidate loci:
+**Hard rule:** never browse `~/.claude/skills`, `.mcp.json`, or `demo-mcp.json` yourself to decide NOT FOUND. Agents miss `~/.tripwire/demo-mcp.json` and emit false negatives for `safe-tool` / `vuln-tool`. Always run this resolve driver once with every requested name:
 
-- **Skills — user scope**: every directory under `~/.claude/skills/`. A directory matches if its basename equals the name OR its `SKILL.md` frontmatter `name:` equals the name (they can differ — check both).
-- **Skills — project scope**: every directory under `./.claude/skills/` (relative to the current working directory), same matching rule.
-- **MCP servers**: config keys, searched in the same order as the enforcement hook: `./.mcp.json` (project scope), `~/.claude.json` (user scope — BOTH the top-level `mcpServers` object AND `projects["<cwd>"].mcpServers`), `~/.tripwire/demo-mcp.json` (demo manifest), `<repo_root>/fixtures/mcp/mcp_manifest.json` (fixtures manifest; `repo_root` from config). A key matches if it equals the name. Config-key resolution only — never derive a directory or path from the entry's `command`/`args`.
+```bash
+cd "<repo_root>" && set -a && source "<env_file>" && set +a && "<uv_bin>" run --extra guard python -c '
+import json, os, sys
+from guard.entry import resolve_operator_name
+cwd = os.getcwd()
+out = []
+for name in sys.argv[1:]:
+    r = resolve_operator_name(name, cwd)
+    if r is None:
+        out.append({"name": name, "found": False})
+    else:
+        out.append({"name": name, "found": True, **r})
+print(json.dumps({"resolutions": out}))
+' <name-1> <name-2> ...
+```
 
-Then canonicalize:
+Parse the JSON privately. For each entry:
 
-- Skill match → identifier is the **canonical absolute path** of the skill directory: `realpath` with symlinks resolved, no trailing slash.
-- MCP match → identifier is **the config key string itself, always** (key-only identity: an MCP server's identity is its config key, never a path derived from `command`/`args`). Known accepted consequence: MCP items store `content_hash` `pending:<key>`, so MCP verdicts carry no content binding, and same-named keys in different projects share one identity row — this matches the plan §5.4 manifest-only rule, now uniform for all MCP servers.
+- `found=false` → ❓ NOT FOUND row (do not call the status driver for that name). Note: **Will be blocked when Tripwire is enabled** — no match in hook loci (`~/.claude/skills`, `.claude/skills`, `.mcp.json`, `~/.claude.json` incl. `projects["<cwd>"]`, `~/.tripwire/demo-mcp.json`, fixtures MCP manifest). Tip: demo skills are `safe-skill` / `vuln-skill` / `amber-skill`; demo MCP keys are `safe-tool` / `vuln-tool` / `amber-tool` (fixture names like `vuln-runtime-download` alias to those when demos are installed).
+- `found=true` → use `identifier` (and `kind`) for Step 4. If `alias_of` is set, the Name column still shows the user’s requested name; optionally append `(as <resolved_as>)` in the Note.
 
-Outcomes per name:
-
-- **No match** → a friendly per-name miss report (becomes a ❓ NOT FOUND row): state the name, list the loci searched (`~/.claude/skills`, `./.claude/skills`, `./.mcp.json`, `~/.claude.json` (incl. `projects["<cwd>"]`), `~/.tripwire/demo-mcp.json`, `<repo_root>/fixtures/mcp/mcp_manifest.json`), and note that `/tw-scan <absolute-path>` works with an explicit path even when name resolution fails. Never a bare error.
-- **Multiple matches** → present the list (path + type for each) via AskUserQuestion and let the user pick one or more; EACH selection proceeds as its own artifact row.
-- **One match** → proceed with the identifier.
+An absolute path the user passed that exists as a skill directory is resolved by the driver — do not invent your own path logic.
 
 ## Step 4 — Query status (shared status procedure)
 
-Run the deterministic status driver ONCE with all resolved identifiers as arguments. Substitute `<repo_root>`, `<env_file>`, `<uv_bin>` from config. Do not improvise your own Supabase queries — use exactly this driver:
+Run the deterministic status driver ONCE with all **found** identifiers as arguments. Substitute `<repo_root>`, `<env_file>`, `<uv_bin>` from config. Do not improvise your own Supabase queries — use exactly this driver:
 
 ```bash
 cd "<repo_root>" && set -a && source "<env_file>" && set +a && "<uv_bin>" run --extra guard python -c '
@@ -91,7 +101,7 @@ print(json.dumps({
 ' <identifier-1> <identifier-2> ...
 ```
 
-The driver prints one JSON object `{config, artifacts}`. NOT FOUND names never reach the driver (they get rows anyway). If the driver itself fails, report the failure and still render every row (status "unknown — status query failed"), never a partial silent result.
+The driver prints one JSON object `{config, artifacts}` — parse it privately; never paste it into the user-facing reply. NOT FOUND names never reach the driver (they get rows anyway). If the driver itself fails, report the failure and still render every row (status "unknown — status query failed"), never a partial silent result.
 
 ## Step 5 — Render the human-readable table
 
@@ -99,10 +109,10 @@ One Markdown table, one row per REQUESTED name (selection rows count individuall
 
 | Name | Type | Status | Note |
 |------|------|--------|------|
-| `safe-changelog-writer` | skill | 🟢 GREEN (fresh) | — |
-| `vuln-runtime-download` | skill | 🔴 RED | **Will be blocked when Tripwire is enabled** |
-| `vuln-command-injection-server` | mcp | 🟠 AMBER | Reported but not blocked at current threshold |
-| `unknown-skill` | — | ❓ NOT FOUND | No match in ~/.claude/skills, .claude/skills, .mcp.json, ~/.claude.json, ~/.tripwire/demo-mcp.json, fixtures manifest |
+| `safe-skill` | skill | 🟢 GREEN (fresh) | — |
+| `vuln-skill` | skill | 🔴 RED | **Will be blocked when Tripwire is enabled** |
+| `safe-tool` | mcp | 🟠 AMBER | Reported but not blocked at current threshold |
+| `unknown-skill` | — | ❓ NOT FOUND | **Will be blocked when Tripwire is enabled** — no match in ~/.claude/skills, .claude/skills, .mcp.json, ~/.claude.json, ~/.tripwire/demo-mcp.json, fixtures manifest |
 | `old-skill` | skill | ⚠️ STALE | Last scanned >14 days ago — blocked until rescanned |
 | `pending-skill` | skill | ⏳ SCANNING | Scan in progress — check back shortly |
 | `new-skill` | skill | 🚫 UNSCANNED | Never scanned — blocked when Tripwire is enabled |
@@ -118,7 +128,7 @@ Row rules (map driver output → row):
 - `state=scanning` → `⏳ SCANNING`; note `Scan in progress — check back shortly`; if `rag` is non-null append `(prior verdict: <rag>)`.
 - `state=unscanned, errored=false` → `🚫 UNSCANNED`; note `Never scanned — blocked when Tripwire is enabled`.
 - `state=unscanned, errored=true` → `🚫 UNSCANNED`; note `Last scan errored — resubmit (run /tw-scan <name>)`.
-- unresolved name → `❓ NOT FOUND`; note `No match in ~/.claude/skills, .claude/skills, .mcp.json, ~/.claude.json, ~/.tripwire/demo-mcp.json, fixtures manifest`.
+- unresolved name → `❓ NOT FOUND`; note ALWAYS the bold **Will be blocked when Tripwire is enabled** plus `— no match in ~/.claude/skills, .claude/skills, .mcp.json, ~/.claude.json, ~/.tripwire/demo-mcp.json, fixtures manifest`. Fail-closed: the hook denies any Skill/mcp__* call it cannot resolve to a known locus (same as unscanned).
 
 The `run /tw-scan <name>` remedy in the STALE, errored, and CHANGED notes actually works because tw-scan always submits with `--force` — without force the CLI would skip unchanged content and a stale/errored state could never clear.
 
@@ -127,32 +137,6 @@ After the table:
 - If config `enabled` is `false`, add: `Note: Tripwire enforcement is currently DISABLED (/tw-disable) — "will be blocked" reports what enforcement would do when enabled; calls are currently bypassed.`
 - If `monitoring_enabled` is `false` while local `enable` is `true`, add a warning that the Supabase platform switch (`config.monitoring_enabled`) is OFF and still gates the guard — effective enforcement is local enable AND platform switch.
 
-## Step 6 — Emit the machine-readable JSON
+## Step 6 — Offer scans for blocked-but-fixable rows
 
-Immediately after the table, a fenced json block, same info (§6.3 shape):
-
-```json
-{
-  "config": { "enabled": true, "scan_validity_days": 14, "threshold": "red" },
-  "artifacts": [
-    {
-      "name": "vuln-runtime-download",
-      "resolved_path": "/abs/path/to/skill",
-      "type": "skill",
-      "state": "fresh",
-      "rag": "red",
-      "scanned_at": "2026-08-01T10:00:00Z",
-      "stale": false,
-      "changed": false,
-      "will_be_blocked": true,
-      "note": "rated red — at/above threshold"
-    }
-  ]
-}
-```
-
-Per row: `name` = requested name; `resolved_path` = identifier (null for NOT FOUND); `type` = `skill` / `mcp` (null for NOT FOUND); `state` = `fresh|stale|scanning|unscanned|not-found`; `rag` = driver rag for fresh states, null otherwise; `scanned_at`, `stale`, `changed`, `will_be_blocked` from the driver (NOT FOUND: `scanned_at` null, `changed` false, `will_be_blocked` null); `note` = the table's note text (unbolded). Both outputs always — table first, then JSON.
-
-## Step 7 — Offer scans for blocked-but-fixable rows
-
-If any rows are `unscanned` (including errored), `stale`, or `changed`, offer to submit them for scanning (AskUserQuestion, listing the names). On yes: read and follow the tw-scan skill's procedure (installed at `~/.claude/skills/tw-scan/SKILL.md`) for exactly those names — its submission step always appends `--force`, which is what actually clears stale/errored/changed states (without force the CLI skips unchanged content and the state never clears) — then re-render the table and JSON with those rows as ⏳ SCANNING. On no: finish.
+If any rows are `unscanned` (including errored), `stale`, or `changed`, offer to submit them for scanning (AskUserQuestion, listing the names). On yes: read and follow the tw-scan skill's procedure (installed at `~/.claude/skills/tw-scan/SKILL.md`) for exactly those names — its submission step always appends `--force`, which is what actually clears stale/errored/changed states (without force the CLI skips unchanged content and the state never clears) — then re-render the Scan Status table only (still no JSON dump) with those rows as ⏳ SCANNING. On no: finish.

--- a/cli/src/discovery.js
+++ b/cli/src/discovery.js
@@ -66,11 +66,42 @@ async function discoverDefaults() {
   return found;
 }
 
+/**
+ * Derive a host directory to tar for Modal from an MCP server config entry.
+ * Identity stays the config key; this path is pack-only (never the identifier).
+ * Looks at command + args for existing filesystem paths that sit in (or are)
+ * an MCP server dir (run.sh / server.py / package.json / …).
+ */
+function resolvePackPathFromEntry(entry) {
+  if (!entry || typeof entry !== 'object') return null;
+  const candidates = [];
+  if (typeof entry.command === 'string') candidates.push(entry.command);
+  if (Array.isArray(entry.args)) {
+    for (const arg of entry.args) {
+      if (typeof arg === 'string') candidates.push(arg);
+    }
+  }
+  for (const raw of candidates) {
+    // Bare tokens (bash, npx, node) are not packable source roots.
+    if (!raw.includes('/') && !raw.includes('\\')) continue;
+    const candidate = path.resolve(raw);
+    if (!existsSync(candidate)) continue;
+    if (looksLikeMcpServer(candidate)) return candidate;
+    const parent = path.dirname(candidate);
+    if (looksLikeMcpServer(parent)) return parent;
+  }
+  return null;
+}
+
 async function tryExpandManifest(filePath) {
   try {
     const json = JSON.parse(await readFile(filePath, 'utf8'));
     if (json.mcpServers && typeof json.mcpServers === 'object') {
-      return Object.keys(json.mcpServers).map(name => ({ manifestEntry: name, manifest: filePath }));
+      return Object.keys(json.mcpServers).map(name => ({
+        manifestEntry: name,
+        manifest: filePath,
+        packPath: resolvePackPathFromEntry(json.mcpServers[name]),
+      }));
     }
   } catch { /* not a valid manifest, treat as regular target */ }
   return null;
@@ -93,8 +124,12 @@ async function annotateWithTypes(resolved) {
   for (const t of resolved) {
     const meta = typeof t === 'string'
       ? await detectType(t)
+      // Key-only identity + pending:<key> hash: never source_on_disk on the key.
       : { type: 'mcp_server', locus: 'unknown', avail: 'unknown' };
-    withTypes.push({ target: typeof t === 'string' ? t : t.manifestEntry, ...meta });
+    const target = typeof t === 'string' ? t : t.manifestEntry;
+    const row = { target, ...meta };
+    if (typeof t !== 'string' && t.packPath) row.packPath = t.packPath;
+    withTypes.push(row);
   }
   return withTypes;
 }

--- a/cli/src/discovery.js
+++ b/cli/src/discovery.js
@@ -66,6 +66,30 @@ async function discoverDefaults() {
   return found;
 }
 
+function collectPathCandidates(entry) {
+  const candidates = [];
+  if (typeof entry.command === 'string') candidates.push(entry.command);
+  if (!Array.isArray(entry.args)) return candidates;
+  for (const arg of entry.args) {
+    if (typeof arg === 'string') candidates.push(arg);
+  }
+  return candidates;
+}
+
+function isPathLikeToken(raw) {
+  // Bare tokens (bash, npx, node) are not packable source roots.
+  return raw.includes('/') || raw.includes('\\');
+}
+
+function resolveMcpServerDir(raw) {
+  if (!isPathLikeToken(raw)) return null;
+  const candidate = path.resolve(raw);
+  if (!existsSync(candidate)) return null;
+  if (looksLikeMcpServer(candidate)) return candidate;
+  const parent = path.dirname(candidate);
+  return looksLikeMcpServer(parent) ? parent : null;
+}
+
 /**
  * Derive a host directory to tar for Modal from an MCP server config entry.
  * Identity stays the config key; this path is pack-only (never the identifier).
@@ -74,21 +98,9 @@ async function discoverDefaults() {
  */
 function resolvePackPathFromEntry(entry) {
   if (!entry || typeof entry !== 'object') return null;
-  const candidates = [];
-  if (typeof entry.command === 'string') candidates.push(entry.command);
-  if (Array.isArray(entry.args)) {
-    for (const arg of entry.args) {
-      if (typeof arg === 'string') candidates.push(arg);
-    }
-  }
-  for (const raw of candidates) {
-    // Bare tokens (bash, npx, node) are not packable source roots.
-    if (!raw.includes('/') && !raw.includes('\\')) continue;
-    const candidate = path.resolve(raw);
-    if (!existsSync(candidate)) continue;
-    if (looksLikeMcpServer(candidate)) return candidate;
-    const parent = path.dirname(candidate);
-    if (looksLikeMcpServer(parent)) return parent;
+  for (const raw of collectPathCandidates(entry)) {
+    const packPath = resolveMcpServerDir(raw);
+    if (packPath) return packPath;
   }
   return null;
 }

--- a/cli/src/modalClient.js
+++ b/cli/src/modalClient.js
@@ -10,12 +10,15 @@ const SCAN_APP = fileURLToPath(new URL('../../sandbox/scan_app.py', import.meta.
 // a tar and passes bytes to remote scan_item — host paths are not on Modal's FS.
 // Do not invoke ::scan_item directly; that skips packing and leaves an empty workdir.
 // `spawnImpl` is injectable for characterization tests (no live Modal).
-export function spawnScanSandbox({ target, itemType, itemId, scanRunId, spawnImpl = defaultSpawn }) {
+export function spawnScanSandbox({ target, itemType, itemId, scanRunId, packPath = null, spawnImpl = defaultSpawn }) {
   return new Promise((resolve, reject) => {
-    const proc = spawnImpl('modal', [
+    const args = [
       'run', SCAN_APP,
-      '--target', target, '--item-type', itemType, '--item-id', itemId, '--scan-run-id', scanRunId
-    ], { stdio: 'inherit' });
+      '--target', target, '--item-type', itemType, '--item-id', itemId, '--scan-run-id', scanRunId,
+    ];
+    // Manifest MCP keys stay the --target identity; packPath is the host dir to tar.
+    if (packPath) args.push('--pack-path', packPath);
+    const proc = spawnImpl('modal', args, { stdio: 'inherit' });
     proc.on('exit', code => code === 0 ? resolve() : reject(new Error('sandbox exited ' + code)));
     proc.on('error', reject); // e.g. modal CLI not installed/logged in
   });

--- a/cli/src/orchestrator.js
+++ b/cli/src/orchestrator.js
@@ -71,7 +71,13 @@ async function dispatchTarget(supabase, target, { batchId, force, spawnFn }) {
     if (runError) throw runError;
 
     try {
-      await spawnFn({ target: target.target, itemType: target.type, itemId: item.id, scanRunId: run.id });
+      await spawnFn({
+        target: target.target,
+        itemType: target.type,
+        itemId: item.id,
+        scanRunId: run.id,
+        packPath: target.packPath || null,
+      });
       return { target: target.target, scanRunId: run.id };
     } catch (err) {
       console.error(`[error] sandbox failed for ${target.target}: ${err.message}`);

--- a/cli/src/setupAgentHooks.js
+++ b/cli/src/setupAgentHooks.js
@@ -10,7 +10,9 @@ const execAsync = promisify(execCb);
 
 // Written to be correct under BOTH regex-search and full-match semantics —
 // a bare `^mcp__` would match nothing under full-match (plan §4.2).
-export const HOOK_MATCHER = '^(Skill|mcp__.*)$';
+// Bash is included so skill-path commands (e.g. …/vuln-skill/install.sh) are
+// gated even when /skill-name loads instructions without a Skill tool event.
+export const HOOK_MATCHER = '^(Skill|Bash|mcp__.*)$';
 const HOOK_TIMEOUT_SECONDS = 10;
 const HANDLER_FILES = ['pre-tool-use.sh', '_guard_entry.py'];
 // Any registration form of our handler ends with this suffix (absolute or `~/…`).
@@ -263,18 +265,36 @@ function isTripwireHookCommand(command, homedir) {
 /**
  * JSON-merge the PreToolUse hook into ~/.claude/settings.json: timestamped backup
  * before any modification, idempotent by handler-command suffix, all other keys
- * preserved, atomic replace on write.
+ * preserved, atomic replace on write. Re-runs refresh the matcher when our
+ * handler is already present but the matcher is stale (e.g. Skill|mcp →
+ * Skill|Bash|mcp) without duplicating the entry.
  */
 function mergeSettings({ fs, settingsPath, hookCommand, homedir, now, log }) {
   const { settings, existed } = readSettingsForMerge({ fs, settingsPath });
   const hooks = assertMergeableShape(settings, settingsPath);
   const preToolUse = hooks.PreToolUse || [];
 
-  const already = preToolUse.some(entry =>
+  const oursIdx = preToolUse.findIndex(entry =>
     entry && Array.isArray(entry.hooks) && entry.hooks.some(h => h && isTripwireHookCommand(h.command, homedir)));
-  if (already) {
-    log(`[setup-agent-hooks] Hook already registered in ${settingsPath} — no duplicate written.`);
-    return { changed: false, backupPath: null };
+
+  if (oursIdx >= 0) {
+    if (preToolUse[oursIdx].matcher === HOOK_MATCHER) {
+      log(`[setup-agent-hooks] Hook already registered in ${settingsPath} — no duplicate written.`);
+      return { changed: false, backupPath: null };
+    }
+    let backupPath = null;
+    if (existed) {
+      backupPath = `${settingsPath}.tripwire-bak-${now().toISOString()}`;
+      fs.copyFileSync(settingsPath, backupPath);
+      log(`[setup-agent-hooks] Backed up ${settingsPath} -> ${backupPath}`);
+    }
+    preToolUse[oursIdx] = { ...preToolUse[oursIdx], matcher: HOOK_MATCHER };
+    hooks.PreToolUse = preToolUse;
+    settings.hooks = hooks;
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    writeFileAtomic({ fs, filePath: settingsPath, data: JSON.stringify(settings, null, 2) + '\n', mode: 0o600 });
+    log(`[setup-agent-hooks] Refreshed Tripwire PreToolUse matcher in ${settingsPath}.`);
+    return { changed: true, backupPath };
   }
 
   let backupPath = null;

--- a/cli/test/discovery-coverage.test.js
+++ b/cli/test/discovery-coverage.test.js
@@ -49,6 +49,38 @@ test('given mcp manifest json when discover then expands server names', async ()
   await rm(dir, { recursive: true, force: true });
 });
 
+test('given stdio mcp manifest when discover then sets packPath from args', async () => {
+  // -- Given --
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'tw-mcp-pack-'));
+  const serverDir = path.join(dir, 'safe-time-server');
+  await mkdir(serverDir);
+  const runSh = path.join(serverDir, 'run.sh');
+  await writeFile(runSh, '#!/bin/bash\n');
+  const manifest = path.join(dir, 'demo-mcp.json');
+  await writeFile(
+    manifest,
+    JSON.stringify({
+      mcpServers: {
+        'safe-tool': { type: 'stdio', command: 'bash', args: [runSh] },
+        'url-only': { url: 'https://example.com/mcp' },
+      },
+    })
+  );
+
+  // -- When --
+  const result = await discoverTargets({ targets: [manifest], useDefaults: false });
+
+  // -- Then — key identity + packPath for local stdio; no packPath for URL-only
+  const safe = result.find((r) => r.target === 'safe-tool');
+  const urlOnly = result.find((r) => r.target === 'url-only');
+  assert.ok(safe);
+  assert.equal(safe.packPath, serverDir);
+  assert.equal(safe.avail, 'unknown'); // pending:<key> hash contract
+  assert.ok(urlOnly);
+  assert.equal(urlOnly.packPath, undefined);
+  await rm(dir, { recursive: true, force: true });
+});
+
 test('given malformed manifest when discover then treats as regular target', async () => {
   // -- Given --
   const dir = await mkdtemp(path.join(os.tmpdir(), 'tw-bad-'));

--- a/cli/test/modalClient.test.js
+++ b/cli/test/modalClient.test.js
@@ -45,6 +45,29 @@ test('spawnScanSandbox passes an absolute scan_app.py path (cwd-independent)', a
   assert.equal(spawned[0].opts.stdio, 'inherit');
 });
 
+test('spawnScanSandbox appends --pack-path when provided (manifest MCP)', async () => {
+  const spawned = [];
+  await spawnScanSandbox({
+    target: 'safe-tool',
+    itemType: 'mcp_server',
+    itemId: 'item-mcp',
+    scanRunId: 'run-mcp',
+    packPath: '/abs/fixtures/mcp/safe-time-server',
+    spawnImpl: (cmd, args) => {
+      spawned.push({ cmd, args });
+      return fakeExitingProc(0);
+    },
+  });
+
+  assert.deepEqual(spawned[0].args.slice(2), [
+    '--target', 'safe-tool',
+    '--item-type', 'mcp_server',
+    '--item-id', 'item-mcp',
+    '--scan-run-id', 'run-mcp',
+    '--pack-path', '/abs/fixtures/mcp/safe-time-server',
+  ]);
+});
+
 test('spawnScanSandbox rejects on non-zero sandbox exit', async () => {
   await assert.rejects(
     spawnScanSandbox({

--- a/cli/test/orchestrator-characterization.test.js
+++ b/cli/test/orchestrator-characterization.test.js
@@ -205,6 +205,7 @@ test('given unchanged content_hash when runScan with force then spawns with expe
       itemType: 'skill',
       itemId: item.id,
       scanRunId: runId,
+      packPath: null,
     });
   });
 });

--- a/cli/test/setupAgentHooks.test.js
+++ b/cli/test/setupAgentHooks.test.js
@@ -284,7 +284,7 @@ test('merges hook into existing settings.json, preserving unrelated keys, with b
         timeout: 10,
       }],
     });
-    assert.equal(HOOK_MATCHER, '^(Skill|mcp__.*)$');
+    assert.equal(HOOK_MATCHER, '^(Skill|Bash|mcp__.*)$');
     const backups = (await readdir(path.join(fx.home, '.claude')))
       .filter(name => name.startsWith('settings.json.tripwire-bak-'));
     assert.equal(backups.length, 1, 'exactly one timestamped backup');
@@ -325,6 +325,27 @@ test('hand-installed `~/…` hook registration is detected — no duplicate entr
     const backups = (await readdir(path.join(fx.home, '.claude')))
       .filter(name => name.startsWith('settings.json.tripwire-bak-'));
     assert.equal(backups.length, 0, 'nothing modified, so no backup');
+  });
+});
+
+test('stale matcher is refreshed on re-run without duplicating the PreToolUse entry', async () => {
+  const settings = JSON.stringify({
+    hooks: {
+      PreToolUse: [{
+        matcher: '^(Skill|mcp__.*)$',
+        hooks: [{ type: 'command', command: '~/.tripwire/hooks/pre-tool-use.sh', timeout: 10 }],
+      }],
+    },
+  }, null, 2);
+  await withFixture({ settings }, async (fx) => {
+    await run(fx);
+    const merged = JSON.parse(readFileSync(path.join(fx.home, '.claude', 'settings.json'), 'utf8'));
+    assert.equal(merged.hooks.PreToolUse.length, 1, 'no duplicate entry');
+    assert.equal(merged.hooks.PreToolUse[0].matcher, HOOK_MATCHER);
+    assert.equal(merged.hooks.PreToolUse[0].hooks[0].command, '~/.tripwire/hooks/pre-tool-use.sh');
+    const backups = (await readdir(path.join(fx.home, '.claude')))
+      .filter(name => name.startsWith('settings.json.tripwire-bak-'));
+    assert.equal(backups.length, 1, 'matcher refresh backs up first');
   });
 });
 

--- a/docs/adr/0017-claude-code-agent-guard-integration.md
+++ b/docs/adr/0017-claude-code-agent-guard-integration.md
@@ -28,9 +28,12 @@ hackathon working plan ("Tripwire × Claude Code Integration — Implementation
 Plan", 2026-08-15 session working document):
 
 - **Handler at `~/.tripwire/hooks/`** (`pre-tool-use.sh` + `_guard_entry.py`),
-  registered under matcher `^(Skill|mcp__.*)$` in `~/.claude/settings.json`
+  registered under matcher `^(Skill|Bash|mcp__.*)$` in `~/.claude/settings.json`
   (JSON-merge preserving existing keys, timestamped backup first). Repo source
-  is a tracked `agent-hooks/` directory.
+  is a tracked `agent-hooks/` directory. Bash is gated only when the command
+  *executes* under a skills locus (cwd inside the skill, a file under it, or
+  `cd <skill> && bash …`); ordinary Bash and skill dirs passed only as data
+  args are not attributed.
 - **Identifier-first lookup + CLI-compatible hash comparison.** Items are
   looked up by `items.identifier` (canonical absolute path, `updated_at desc
   limit 1`), and the CLI's sorted-directory-walk SHA-256 (`cli/src/hash.js`,
@@ -69,17 +72,26 @@ Plan", 2026-08-15 session working document):
 
 ### Honest limits (recorded, not hidden)
 
-- **Same-user Bash tampering.** `Bash` is an unmatched tool, so an injected
-  agent can write `enable: false` (or delete/corrupt the config) in a single
-  call. Missing/corrupt config denies, but a correctly-written disable
-  bypasses enforcement — unfixable at this layer. Detection is advisory only,
-  via the optional SessionStart sweep that loudly reports enforcement state
-  at session start.
-- **User-typed invocation paths.** Whether user-typed (vs model-initiated)
-  skill invocations produce a hook-visible event is pending the empirical
-  step-2 spike; if user-typed paths bypass the hook, that is a scoping
-  limitation of this layer. Custom slash commands (`.claude/commands`) are
-  out of Phase-1 scope — a recorded known gap.
+- **Same-user Bash tampering (enable flip).** An injected agent can still
+  `Bash`-write `"enable": false` (or delete/corrupt the config) in a single
+  call — that path is unmatched by skill-path attribution. Missing/corrupt
+  config denies, but a correctly-written disable bypasses enforcement —
+  unfixable at this layer. Detection is advisory only, via the optional
+  SessionStart sweep that loudly reports enforcement state at session start.
+- **Bash skill-path attribution (closed gap).** Matcher is
+  `^(Skill|Bash|mcp__.*)$`. Bash is allowed immediately unless the command
+  *executes* under a skills locus (cwd inside the skill, a file under it such
+  as `install.sh`, or `cd <skill> && bash …`); then the owning skill's
+  verdict gates the call. Skill directories passed only as data args (status/
+  scan drivers) are not attributed — otherwise unscanned skills would
+  deadlock `/tw-verify` and `/tw-scan`. This closes the slash-command path
+  where `/vuln-skill` injects instructions and the agent runs `install.sh`
+  via Bash without a Skill tool PreToolUse event.
+- **User-typed Skill tool events.** Whether user-typed (vs model-initiated)
+  skill invocations produce a hook-visible Skill event is still harness-
+  dependent; Bash attribution above covers the dangerous follow-on
+  execution. Custom slash commands (`.claude/commands`) remain out of
+  Phase-1 scope for non-skill paths.
 - **Service-role key in the hook environment.** Accepted for the hackathon:
   the key stays in `.env` (never in `settings.json`; gitleaks runs
   repo-wide), but every intercepted call sources it. An anon-key read path

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -21,7 +21,7 @@ exhaustive), enough to demo each heatmap state and the main finding anchor types
 | `skills/vuln-prompt-injection-notes` | skill | red | hidden "SYSTEM OVERRIDE" instructions in an HTML comment |
 | `skills/vuln-runtime-download` | skill | red | `curl \| bash` in `install.sh` (CWE-494) |
 | `skills/disagreement-naive-domain-check` | skill | amber (borderline) | naive prefix-match allowlist bypass — designed to plausibly split scanners |
-| `skills/vuln-dependency-lodash` | skill | red (dependency) | pinned `lodash@4.17.15` (CVE-2020-8203, CVE-2021-23337) in `package.json` + lockfile — SCA/dependency-scanner demo target |
+| `skills/vuln-dependency-lodash` | skill | red (dependency) | pinned `lodash@4.17.15` (CVE-2020-8203, CVE-2021-23337) in `package.json` + lockfile — SCA/dependency-scanner demo target; ignored by repo OSV via `osv-scanner.toml` + CI `--experimental-exclude=fixtures` |
 | `mcp/safe-time-server` | mcp | green | clean baseline |
 | `mcp/vuln-command-injection-server` | mcp | red | `shell=True` + unsanitized interpolation (CWE-78), file- and entity-anchored simultaneously |
 | `mcp/vuln-hardcoded-secret-server` | mcp | red | hardcoded API key in `config.py` (CWE-798) |

--- a/fixtures/skills/vuln-dependency-lodash/osv-scanner.toml
+++ b/fixtures/skills/vuln-dependency-lodash/osv-scanner.toml
@@ -1,0 +1,6 @@
+# Intentional SCA demo target — pinned vulnerable lodash for Tripwire scanner demos.
+# See fixtures/README.md. Keep this ignore so repo SCA (CI / security-scan.sh) does not
+# fail on deliberate vulnerabilities.
+[[PackageOverrides]]
+ignore = true
+reason = "Intentional SCA demo fixture — pinned vulnerable lodash for Tripwire scanner demos. See fixtures/README.md."

--- a/guard/__init__.py
+++ b/guard/__init__.py
@@ -4,7 +4,7 @@ Supabase imports are lazy throughout, so importing ``guard.*`` works without
 the optional ``guard`` dependency group installed.
 """
 
-from guard.entry import decide, extract_target, main, resolve_artifact
+from guard.entry import decide, extract_target, main, resolve_artifact, resolve_operator_name
 from guard.guard_hook import check_call, check_call_by_identifier
 from guard.status import (
     DEFAULT_VALIDITY_DAYS,
@@ -24,4 +24,5 @@ __all__ = [
     "main",
     "make_client",
     "resolve_artifact",
+    "resolve_operator_name",
 ]

--- a/guard/entry.py
+++ b/guard/entry.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from pathlib import Path
 from typing import Any, TextIO
@@ -46,16 +47,43 @@ _CONFIG_TAMPER_REASON = (
 # The trailing keys stay as defensive fallbacks for other harness versions.
 _SKILL_NAME_KEYS = ("skill", "command", "name", "skillName")
 
+# Path-like tokens in a Bash command that may point into a skills directory.
+# Absolute, ~/…, ./…, ../…, or any token containing a slash / ending in a
+# common script extension. Broad on purpose for token discovery; attribution
+# itself is narrowed in ``_extract_bash_skill_target`` so a skill *directory*
+# passed only as data (``/tw-verify`` / ``/tw-scan`` status drivers) is not
+# gated — otherwise unscanned skills deadlock their own remediation path.
+_BASH_PATH_TOKEN = (
+    r"(?:~|/|\./|\.\./)[^\s;|&\"']+"
+    r"|(?:[^\s;|&\"']+/)+[^\s;|&\"']+"
+    r"|[^\s;|&\"']+\.(?:sh|py|js|mjs|ts|bash)"
+)
+
+# Shell-script invocation shapes: ``bash install.sh``, ``source ./x``, ``./run.sh``.
+# Used with a skill-directory mention to catch ``cd <skill> && bash install.sh``.
+_BASH_SCRIPT_EXEC = re.compile(
+    r"(?:^|[\n;|&])\s*(?:bash|sh|zsh|dash|source|\.)\s+"
+    r"|(?:^|[\n;|&])\s*\./[^\s;|&]+"
+)
+
 
 # ─── stdin payload → target artifact ─────────────────────────────────────────
 
 
-def extract_target(payload: dict) -> dict | None:
+def extract_target(payload: dict, *, cwd: str | None = None) -> dict | None:
     """Map a PreToolUse payload to ``{"kind": "skill"|"mcp", "name": str}``.
 
-    Returns None for tools outside the enforcement triad, and for Skill
-    payloads whose input carries no recognizable name (the caller denies that
-    case — the tool *was* matched, so an unresolvable shape must fail closed).
+    Returns None for tools outside the enforcement set, for ordinary Bash
+    that does not touch a skills path, and for Skill payloads whose input
+    carries no recognizable name (the caller denies that Skill case — the
+    tool *was* matched, so an unresolvable shape must fail closed).
+
+    Bash is attributed when the command *executes* under
+    ``~/.claude/skills/<name>/`` or ``<project>/.claude/skills/<name>/``
+    (cwd inside the skill, a file under it, or ``cd <skill> && bash …``) —
+    closing the slash-command gap where ``/vuln-skill`` injects instructions
+    and the agent runs ``install.sh`` via Bash without a Skill tool event.
+    Skill directories passed only as data arguments are not attributed.
     """
     tool_name = str(payload.get("tool_name") or "")
     if tool_name == "Skill":
@@ -71,6 +99,8 @@ def extract_target(payload: dict) -> dict | None:
                 if name:
                     return {"kind": "skill", "name": name}
         return None
+    if tool_name == "Bash":
+        return _extract_bash_skill_target(payload, cwd if cwd is not None else os.getcwd())
     if tool_name.startswith("mcp__"):
         # mcp__<server>__<tool>; server names may themselves contain "__",
         # so strip only the trailing tool segment.
@@ -78,6 +108,92 @@ def extract_target(payload: dict) -> dict | None:
         if server:
             return {"kind": "mcp", "name": server}
         return None
+    return None
+
+
+def _payload_cwd(payload: dict, fallback: str) -> str:
+    raw = payload.get("cwd")
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    return fallback
+
+
+def _bash_path_tokens(command: str) -> list[str]:
+    return re.findall(_BASH_PATH_TOKEN, command)
+
+
+def _skill_name_for_resolved_path(resolved: str, cwd: str) -> str | None:
+    """If ``resolved`` lies under a skills root, return the skill dir basename."""
+    for root in _skill_roots(cwd):
+        if not os.path.isdir(root):
+            continue
+        root_resolved = os.path.realpath(root)
+        try:
+            if os.path.commonpath([root_resolved, resolved]) != root_resolved:
+                continue
+        except ValueError:
+            continue
+        rel = os.path.relpath(resolved, root_resolved)
+        parts = [p for p in rel.split(os.sep) if p and p not in (".",)]
+        if not parts or parts[0] == "..":
+            continue
+        skill_name = parts[0]
+        skill_dir = os.path.join(root_resolved, skill_name)
+        if os.path.isdir(skill_dir):
+            return skill_name
+    return None
+
+
+def _resolve_candidate_path(token: str, cwd: str) -> str | None:
+    """Expand ``token`` relative to cwd / ``~`` and realpath it when possible."""
+    expanded = os.path.expanduser(token)
+    if not os.path.isabs(expanded):
+        expanded = os.path.join(cwd, expanded)
+    try:
+        return os.path.realpath(expanded)
+    except OSError:
+        return None
+
+
+def _extract_bash_skill_target(payload: dict, cwd: str) -> dict | None:
+    """Attribute Bash to a skill only when the command *executes* under it.
+
+    Gated shapes (unscanned/RED ⇒ deny):
+    - payload cwd inside a skill directory
+    - a *file* under a skill directory is referenced (e.g. ``…/install.sh``)
+    - a skill directory is named and the command invokes a shell script
+      (``cd …/vuln-skill && bash install.sh``)
+
+    Not gated: skill directories passed only as data args (status/scan drivers).
+    """
+    tool_input = payload.get("tool_input")
+    command = ""
+    if isinstance(tool_input, dict):
+        raw_cmd = tool_input.get("command")
+        if isinstance(raw_cmd, str):
+            command = raw_cmd
+
+    effective_cwd = _payload_cwd(payload, cwd)
+    cwd_resolved = _resolve_candidate_path(effective_cwd, effective_cwd)
+    if cwd_resolved is not None:
+        cwd_skill = _skill_name_for_resolved_path(cwd_resolved, effective_cwd)
+        if cwd_skill:
+            return {"kind": "skill", "name": cwd_skill}
+
+    skill_dirs_mentioned: list[str] = []
+    for token in _bash_path_tokens(command):
+        resolved = _resolve_candidate_path(token, effective_cwd)
+        if resolved is None:
+            continue
+        name = _skill_name_for_resolved_path(resolved, effective_cwd)
+        if not name:
+            continue
+        if os.path.isfile(resolved):
+            return {"kind": "skill", "name": name}
+        skill_dirs_mentioned.append(name)
+
+    if skill_dirs_mentioned and _BASH_SCRIPT_EXEC.search(command):
+        return {"kind": "skill", "name": skill_dirs_mentioned[0]}
     return None
 
 
@@ -246,6 +362,73 @@ def resolve_artifact(target: dict, cwd: str) -> str | None:
     return None
 
 
+# Fixture basename → demo install name (scripts/install-demo-artifacts.sh).
+# Used only by /tw-verify and /tw-scan operator resolution — the PreToolUse
+# hook never sees fixture names (Claude registers the rewritten demo name).
+_OPERATOR_ALIASES = {
+    "vuln-runtime-download": "vuln-skill",
+    "safe-changelog-writer": "safe-skill",
+    "disagreement-naive-domain-check": "amber-skill",
+}
+
+
+def resolve_operator_name(name: str, cwd: str) -> dict[str, str] | None:
+    """Resolve a /tw-verify or /tw-scan name the same way the hook would.
+
+    Order: explicit path with ``SKILL.md`` → skill locus → MCP config key
+    (incl. ``~/.tripwire/demo-mcp.json``) → demo fixture alias. Returns
+    ``{"identifier", "kind"}`` plus optional ``resolved_as`` / ``alias_of``,
+    or ``None`` when nothing matches (caller reports NOT FOUND).
+    """
+    if not isinstance(name, str):
+        return None
+    token = name.strip()
+    if not token:
+        return None
+
+    # Explicit path (absolute or containing a separator) → skill dir if present.
+    if (
+        os.path.isabs(token)
+        or (os.path.sep in token)
+        or (os.path.altsep and os.path.altsep in token)
+    ):
+        candidate = token if os.path.isabs(token) else os.path.join(cwd, token)
+        if os.path.isdir(candidate) and os.path.isfile(os.path.join(candidate, "SKILL.md")):
+            return {
+                "identifier": os.path.realpath(candidate),
+                "kind": "skill",
+                "resolved_as": token,
+            }
+
+    skill = _resolve_skill(token, cwd)
+    if skill is not None:
+        return {"identifier": skill, "kind": "skill", "resolved_as": token}
+
+    mcp = _resolve_mcp_server(token, cwd)
+    if mcp is not None:
+        return {"identifier": mcp, "kind": "mcp", "resolved_as": token}
+
+    alias = _OPERATOR_ALIASES.get(token)
+    if alias and alias != token:
+        skill = _resolve_skill(alias, cwd)
+        if skill is not None:
+            return {
+                "identifier": skill,
+                "kind": "skill",
+                "resolved_as": alias,
+                "alias_of": token,
+            }
+        mcp = _resolve_mcp_server(alias, cwd)
+        if mcp is not None:
+            return {
+                "identifier": mcp,
+                "kind": "mcp",
+                "resolved_as": alias,
+                "alias_of": token,
+            }
+    return None
+
+
 # ─── verdict → decision ──────────────────────────────────────────────────────
 
 
@@ -279,15 +462,20 @@ def decide(
     check = check_fn if check_fn is not None else check_call_by_identifier
 
     tool_name = str(payload.get("tool_name") or "")
-    enforced = tool_name == "Skill" or tool_name.startswith("mcp__")
+    enforced = tool_name == "Skill" or tool_name == "Bash" or tool_name.startswith("mcp__")
     if not enforced:
-        # The matcher only routes Skill|mcp__* here; anything else is a
-        # misconfiguration — allowing avoids bricking ordinary tools, and the
-        # matcher (not this branch) is the enforcement boundary.
+        # Matcher should only route Skill|Bash|mcp__* here; anything else is a
+        # misconfiguration — allowing avoids bricking ordinary tools.
         return {"allow": True, "reason": f"tool '{tool_name}' not subject to tripwire guard"}
 
-    target = extract_target(payload)
+    target = extract_target(payload, cwd=cwd)
     if target is None:
+        if tool_name == "Bash":
+            # Ordinary Bash (no skills-path touch) is not gated.
+            return {
+                "allow": True,
+                "reason": "bash command does not reference a tripwire-scanned skill path",
+            }
         return {
             "allow": False,
             "reason": _block_reason(
@@ -379,7 +567,12 @@ def main(*, stdin: TextIO | None = None, stdout: TextIO | None = None) -> int:
             payload = json.loads(stdin.read() or "{}")
             if not isinstance(payload, dict):
                 raise ValueError("hook payload is not a JSON object")
-            decision = decide(payload, config)
+            payload_cwd = payload.get("cwd")
+            decision = decide(
+                payload,
+                config,
+                cwd=payload_cwd if isinstance(payload_cwd, str) and payload_cwd.strip() else None,
+            )
     except Exception:
         decision = {"allow": False, "reason": _GUARD_ERROR_REASON}
     print(json.dumps(format_decision(decision)), file=stdout)

--- a/guard/tests/_fakes.py
+++ b/guard/tests/_fakes.py
@@ -66,7 +66,7 @@ class NoneReturningClient:
         return self
 
     def __getattr__(self, _name: str) -> Any:
-        return lambda *args, **kwargs: self
+        return lambda *_args, **_kwargs: self
 
     def execute(self) -> None:
         return None

--- a/guard/tests/test_entry.py
+++ b/guard/tests/test_entry.py
@@ -78,6 +78,111 @@ def test_given_non_target_tool_then_none() -> None:
     assert entry.extract_target({}) is None
 
 
+def test_given_bash_command_with_user_skill_path_then_skill_target(
+    fake_home: Path, tmp_path: Path
+) -> None:
+    skill_dir = _install_skill(fake_home, "vuln-skill")
+    (skill_dir / "install.sh").write_text("#!/bin/sh\necho setup\n")
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {"command": f"bash {skill_dir}/install.sh"},
+    }
+
+    assert entry.extract_target(payload, cwd=str(tmp_path)) == {
+        "kind": "skill",
+        "name": "vuln-skill",
+    }
+
+
+def test_given_bash_cwd_inside_skill_then_relative_script_attributed(
+    fake_home: Path, tmp_path: Path
+) -> None:
+    skill_dir = _install_skill(fake_home, "vuln-skill")
+    (skill_dir / "install.sh").write_text("#!/bin/sh\necho setup\n")
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {"command": "bash ./install.sh"},
+        "cwd": str(skill_dir),
+    }
+
+    assert entry.extract_target(payload, cwd=str(tmp_path)) == {
+        "kind": "skill",
+        "name": "vuln-skill",
+    }
+
+
+def test_given_bash_tilde_skill_path_then_skill_target(fake_home: Path, tmp_path: Path) -> None:
+    skill_dir = _install_skill(fake_home, "vuln-skill")
+    (skill_dir / "install.sh").write_text("#!/bin/sh\necho setup\n")
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {"command": "bash ~/.claude/skills/vuln-skill/install.sh"},
+    }
+
+    assert entry.extract_target(payload, cwd=str(tmp_path)) == {
+        "kind": "skill",
+        "name": "vuln-skill",
+    }
+
+
+def test_given_bash_skill_dir_only_as_data_arg_then_no_target(
+    fake_home: Path, tmp_path: Path
+) -> None:
+    """
+    Scenario: Status/scan driver Bash that only passes a skill directory as a
+    data argument is not attributed — otherwise unscanned skills deadlock
+    /tw-verify and /tw-scan (the status query itself would be denied).
+    Slice: Bash skill-path attribution — directory-as-data exemption
+
+    Given a Bash command that names a skill directory only as an argv to an
+    unrelated interpreter (uv/python status driver shape),
+    When extract_target maps the payload,
+    Then no skill target is returned (ordinary Bash / not gated).
+    """
+    ### Given
+    skill_dir = _install_skill(fake_home, "vuln-skill")
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {
+            "command": (f'uv run --extra guard python -c "print(1)" {skill_dir}'),
+        },
+    }
+
+    ### When
+    actual = entry.extract_target(payload, cwd=str(tmp_path))
+
+    ### Then
+    assert actual is None, f"skill directory as data argv must not attribute; got {actual!r}"
+
+
+def test_given_bash_cd_skill_dir_and_run_install_then_skill_target(
+    fake_home: Path, tmp_path: Path
+) -> None:
+    """
+    Scenario: cd into a skill then run install.sh is still attributed.
+    Slice: Bash skill-path attribution — compound cd + script
+
+    Given a Bash command that cds into an unscanned skill and runs install.sh,
+    When extract_target maps the payload,
+    Then the owning skill is the target (fail-closed for unscanned/RED).
+    """
+    ### Given
+    skill_dir = _install_skill(fake_home, "vuln-skill")
+    (skill_dir / "install.sh").write_text("#!/bin/sh\necho setup\n")
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {
+            "command": f"cd {skill_dir} && bash install.sh",
+        },
+    }
+
+    ### When
+    actual = entry.extract_target(payload, cwd=str(tmp_path))
+
+    ### Then
+    assert actual == {"kind": "skill", "name": "vuln-skill"}
+
+
 # ─── resolve_artifact: skills ────────────────────────────────────────────────
 
 
@@ -308,6 +413,72 @@ def test_given_unknown_mcp_server_then_none(fake_home: Path, tmp_path: Path) -> 
     assert entry.resolve_artifact({"kind": "mcp", "name": "nope"}, str(tmp_path)) is None
 
 
+# ─── resolve_operator_name (/tw-verify|/tw-scan) ─────────────────────────────
+
+
+def test_given_demo_mcp_key_when_operator_resolve_then_found(
+    fake_home: Path, tmp_path: Path
+) -> None:
+    """
+    Scenario: Operator names like safe-tool resolve via demo-mcp.json without
+    hand-searching loci (the LLM locus walk was producing false NOT FOUND).
+    Slice: resolve_operator_name — MCP demo keys
+
+    Given ~/.tripwire/demo-mcp.json lists safe-tool,
+    When resolve_operator_name is called with that bare key,
+    Then the identifier is the config key and kind is mcp.
+    """
+    ### Given
+    tripwire_dir = fake_home / ".tripwire"
+    tripwire_dir.mkdir()
+    (tripwire_dir / "demo-mcp.json").write_text(
+        json.dumps({"mcpServers": {"safe-tool": {"command": "bash", "args": ["run.sh"]}}})
+    )
+
+    ### When
+    resolved = entry.resolve_operator_name("safe-tool", str(tmp_path))
+
+    ### Then
+    assert resolved == {
+        "identifier": "safe-tool",
+        "kind": "mcp",
+        "resolved_as": "safe-tool",
+    }, f"Expected demo MCP key resolution, got {resolved!r}"
+
+
+def test_given_fixture_alias_when_operator_resolve_then_demo_skill(
+    fake_home: Path, tmp_path: Path
+) -> None:
+    """
+    Scenario: Fixture basename vuln-runtime-download aliases to installed vuln-skill.
+    Slice: resolve_operator_name — demo skill aliases
+
+    Given vuln-skill is installed under ~/.claude/skills,
+    When the operator asks for the fixture name vuln-runtime-download,
+    Then resolution lands on the installed vuln-skill directory.
+    """
+    ### Given
+    skill_dir = _install_skill(fake_home, "vuln-skill")
+
+    ### When
+    resolved = entry.resolve_operator_name("vuln-runtime-download", str(tmp_path))
+
+    ### Then
+    assert resolved is not None
+    assert resolved["identifier"] == os.path.realpath(str(skill_dir))
+    assert resolved["kind"] == "skill"
+    assert resolved["resolved_as"] == "vuln-skill"
+    assert resolved["alias_of"] == "vuln-runtime-download"
+
+
+def test_given_unknown_operator_name_then_none(fake_home: Path, tmp_path: Path) -> None:
+    ### Given / When
+    resolved = entry.resolve_operator_name("nope-not-installed", str(tmp_path))
+
+    ### Then
+    assert resolved is None
+
+
 # ─── decide ──────────────────────────────────────────────────────────────────
 
 
@@ -385,6 +556,53 @@ def test_given_skill_payload_with_no_name_then_deny(tmp_path: Path) -> None:
 def test_given_non_target_tool_then_allow(tmp_path: Path) -> None:
     decision = entry.decide(
         {"tool_name": "Bash", "tool_input": {"command": "ls"}}, CONFIG, cwd=str(tmp_path)
+    )
+
+    assert decision["allow"] is True
+
+
+def test_given_bash_running_blocked_skill_script_then_deny(fake_home: Path, tmp_path: Path) -> None:
+    skill_dir = _install_skill(fake_home, "vuln-skill")
+    (skill_dir / "install.sh").write_text("#!/bin/sh\necho setup\n")
+    seen: dict[str, Any] = {}
+
+    def check_fn(identifier: str, validity_days: int, content_path: str | None = None) -> dict:
+        seen.update(identifier=identifier, content_path=content_path)
+        return {"allow": False, "reason": "never scanned — guard fails closed", "status": "grey"}
+
+    decision = entry.decide(
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": f"bash {skill_dir}/install.sh"},
+        },
+        CONFIG,
+        cwd=str(tmp_path),
+        check_fn=check_fn,
+    )
+
+    assert decision["allow"] is False
+    assert "vuln-skill" in decision["reason"]
+    assert seen["identifier"] == str(skill_dir.resolve())
+    assert seen["content_path"] == seen["identifier"]
+
+
+def test_given_bash_running_allowed_skill_script_then_allow(
+    fake_home: Path, tmp_path: Path
+) -> None:
+    skill_dir = _install_skill(fake_home, "safe-skill")
+    (skill_dir / "install.sh").write_text("#!/bin/sh\necho setup\n")
+
+    def check_fn(identifier: str, validity_days: int, content_path: str | None = None) -> dict:
+        return {"allow": True, "reason": "rated green — below threshold", "status": "green"}
+
+    decision = entry.decide(
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": f"bash {skill_dir}/install.sh"},
+        },
+        CONFIG,
+        cwd=str(tmp_path),
+        check_fn=check_fn,
     )
 
     assert decision["allow"] is True

--- a/sandbox/scan_app.py
+++ b/sandbox/scan_app.py
@@ -280,13 +280,23 @@ def _scan_item_inner(
 
 
 @app.local_entrypoint()
-def main(target: str, item_type: str, item_id: str, scan_run_id: str):
+def main(
+    target: str,
+    item_type: str,
+    item_id: str,
+    scan_run_id: str,
+    pack_path: str = "",
+):
     """Host-side wrapper: pack local dirs, then invoke the remote sandbox.
 
     Invoked by the CLI via ``modal run sandbox/scan_app.py`` (not ``::scan_item``)
     so this code runs where the fixture filesystem is visible.
+
+    ``pack_path`` is optional: for manifest MCP keys, ``target`` is the config
+    key (item identity) while ``pack_path`` is the host directory to tar.
     """
-    archive = _maybe_pack_local_target(target)
+    pack_root = pack_path or target
+    archive = _maybe_pack_local_target(pack_root)
     if archive is not None:
         print(f"[acquire] packed local target ({len(archive)} bytes) → remote sandbox")
     scan_item.remote(

--- a/sandbox/tests/test_acquire_target.py
+++ b/sandbox/tests/test_acquire_target.py
@@ -317,15 +317,52 @@ def test_given_local_target_when_host_entrypoint_runs_then_it_hands_the_archive_
 
     ### When
     with (
-        patch("scan_app._maybe_pack_local_target", return_value=archive),
+        patch("scan_app._maybe_pack_local_target", return_value=archive) as pack,
         patch("scan_app.scan_item") as scan_item,
     ):
         main("fixtures/skill", "skill", "item-1", "run-1")
 
     ### Then
+    pack.assert_called_once_with("fixtures/skill")
     scan_item.remote.assert_called_once_with(
         target="fixtures/skill",
         item_type="skill",
+        item_id="item-1",
+        scan_run_id="run-1",
+        target_archive=archive,
+    )
+
+
+def test_given_manifest_key_and_pack_path_when_entrypoint_runs_then_packs_pack_path() -> None:
+    """
+    Scenario: Manifest MCP keys keep key identity while packing the fixture dir.
+    Slice: demo-mcp.json / key-only identity
+
+    Given target is a bare MCP config key and pack_path is a local server dir,
+    When the Modal entrypoint starts,
+    Then packing uses pack_path and remote still sees the key as target.
+    """
+    ### Given
+    archive = b"packed-mcp-fixture"
+
+    ### When
+    with (
+        patch("scan_app._maybe_pack_local_target", return_value=archive) as pack,
+        patch("scan_app.scan_item") as scan_item,
+    ):
+        main(
+            "safe-tool",
+            "mcp_server",
+            "item-1",
+            "run-1",
+            pack_path="/abs/fixtures/mcp/safe-time-server",
+        )
+
+    ### Then
+    pack.assert_called_once_with("/abs/fixtures/mcp/safe-time-server")
+    scan_item.remote.assert_called_once_with(
+        target="safe-tool",
+        item_type="mcp_server",
         item_id="item-1",
         scan_run_id="run-1",
         target_archive=archive,

--- a/scripts/security-scan.sh
+++ b/scripts/security-scan.sh
@@ -131,11 +131,16 @@ if $RUN_OSV; then
     warn "  go install github.com/google/osv-scanner/cmd/osv-scanner@latest"
     SCANS_SKIPPED=$((SCANS_SKIPPED + 1))
   elif $DRY_RUN; then
-    info "DRY RUN: would run: osv-scanner --recursive ."
+    info "DRY RUN: would run: osv-scanner --recursive --experimental-exclude=fixtures --experimental-exclude=prototypes --experimental-exclude=internal-docs ."
   else
     SCANS_RUN=$((SCANS_RUN + 1))
-    echo "  Running: osv-scanner (recursive lockfile scan)..."
-    if ! osv-scanner --recursive .; then
+    echo "  Running: osv-scanner (recursive lockfile scan, fixtures/prototypes excluded)..."
+    # Parity with Trivy skip-dirs; fixture-local osv-scanner.toml also ignores intentional vulns.
+    if ! osv-scanner --recursive \
+      --experimental-exclude=fixtures \
+      --experimental-exclude=prototypes \
+      --experimental-exclude=internal-docs \
+      .; then
       fail "OSV-Scanner found dependency vulnerabilities"
       SCANS_FAILED=$((SCANS_FAILED + 1))
     else


### PR DESCRIPTION
## Summary
- feat(guard): gate Bash/MCP skill paths and harden agent-hooks flow — attribute skill installs from Bash/MCP, pass `packPath` through scan spawn, fast-path ordinary Bash in the pre-tool hook, silence vulture unused-arg noise in test fakes, and exclude intentional vuln fixtures from OSV scans
- refactor(cli): split `resolvePackPathFromEntry` helpers so ESLint cyclomatic complexity stays ≤10 (fixes CI lint on `discovery.js`)

## Test Results

| Stack | Status | Tests | Passed | Failed | Skipped | Duration |
|-------|--------|-------|--------|--------|---------|----------|
| Python (pytest) | ✅ | 295 | 295 | 0 | 0 | 5.3s |
| CLI (node:test + c8) | ✅ | 105 | 105 | 0 | 0 | 4.2s |

### Coverage

| Stack | Statements | Branches | Methods / Functions | Lines |
|-------|------------|----------|---------------------|-------|
| Python (`sandbox`) | 96.7% | 96.4% | — | 96.8% (701/724) |
| CLI (`cli/`) | 95.5% | 84.5% | 94.2% | 95.5% (1499/1569) |

## Quality Gates

| Check | Result |
|-------|--------|
| T1 (`quality-gates.sh --quick`) | ✅ passed |
| ruff check / format | ✅ |
| mypy | ✅ |
| bandit | ✅ |
| xenon (scan_app C / scanners D) | ✅ |
| vulture | ✅ |
| gitleaks | ✅ |
| CLI ESLint complexity (≤10) | ✅ (`npm run lint` in `cli/`) |

## Checklist

- [x] `./scripts/quality-gates.sh` passes locally
- [x] New tests added or updated (or change is docs-only)
- [x] Docs updated where applicable
- [ ] No secrets or credentials committed

<!-- tripwire-complexity:start -->
## Complexity

_Automatically refreshed by CI for product-code changes._

| Scope | Tool | Result |
| --- | --- | --- |
| Python (`sandbox/`) | Radon | highest CC **28** (rank **D**), 222 blocks |
| CLI (`cli/`) | ESLint | 0 function(s) above CC 10 |

<!-- tripwire-complexity:end -->