### PR TITLE
chore: block direct commits to main via pre-commit hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,14 +41,31 @@ Fall back to Grep/Glob/Read **only** when the graph doesn't cover what you need.
 
 ## Slice-first rule (MUST NOT skip)
 
-**Never write code before a slice stub exists.**
+**Never write code before a slice stub exists AND a branch is created.**
 
 When `/enhanced-flow-planner` detects continuation mode:
 1. Run plan-health-check
 2. Run plan-modifier to **add the slice to TRAIL.md + PROGRESS.md + a slice stub file** under `docs/plan/slices/`
-3. Only then write code
+3. Create a branch: `git checkout -b slice/<N>-<short-name>`
+4. Only then write code
 
-"Keep it simple" narrows scope. It does not bypass the slice stub. The stub *is* the requirement contract — without it there is no acceptance criteria and no gate evidence.
+"Keep it simple" narrows scope. It does not bypass the slice stub or the branch. The stub *is* the requirement contract — without it there is no acceptance criteria and no gate evidence. The branch *is* the delivery unit — without it there is no reviewable PR.
+
+## Branch-before-commit rule (enforced by hook)
+
+**Never commit directly to `main`.** The `pre-commit` hook blocks it.
+
+Every piece of work — however small — goes on a branch:
+```bash
+git checkout -b <type>/<short-description>   # feat/ fix/ docs/ slice/ chore/
+```
+
+Emergency override (coordinators only, never for feature work):
+```bash
+ALLOW_MAIN_COMMIT=1 git commit ...
+```
+
+The hook allows merge commits through automatically. Everything else on `main` is blocked.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a branch guard at the top of `.git/hooks/pre-commit` — any commit on `main`/`master` is rejected with a clear message and instructions to create a branch first
- Merge commits pass through automatically (checked via `.git/MERGE_HEAD`)
- Emergency override available via `ALLOW_MAIN_COMMIT=1 git commit` for coordinators only
- Updates `CLAUDE.md` to document the branch-before-commit rule alongside the slice-first rule, and adds "create branch" as step 3 in the slice workflow

## Why

During slice-41 all code was committed directly to `main`, making the PR diff empty (the content was already merged before the branch existed). This required a complex reorientation involving cherry-picks, force-pushes, and merge commit resolution. The hook prevents this class of mistake at the point of commit.

## Test Results

Manual: verified the hook fires and blocks `git commit` on `main` with a clear message. Merge commits are unaffected.

## Quality Gates

| Gate | Result |
|---|---|
| Hook blocks commit on main | ✅ Verified |
| Hook allows merge commits | ✅ Verified |
| ALLOW_MAIN_COMMIT=1 override | ✅ Verified |

## Checklist

- [x] `./scripts/quality-gates.sh` passes locally
- [x] New tests added or updated (or change is docs-only)
- [x] Docs updated where applicable (CLAUDE.md)
- [x] No secrets or credentials committed