### PR TITLE
docs(design): Tessl 5-row expansion — design doc + Wave 12-L slice stubs

### DIFF
--- a/docs/design/tessl-5-row-expansion.md
+++ b/docs/design/tessl-5-row-expansion.md
@@ -1,0 +1,371 @@
+# Design: Tessl 5-Row Expansion
+
+**Status**: Draft  
+**Date**: 2026-08-24  
+**Scope**: Design document only — no implementation code. Covers schema extension, resume logic, ID lineage, and UI contract for replacing the single Tessl scanner row with 5 flat capability rows.
+
+---
+
+## Verified Coverage Gaps
+
+The task prompt lists 6 Coverage Gaps to "flag, do not infer." Each is resolved below against the actual repo (file:line) or explicitly marked Still Open.
+
+| # | Coverage Gap | Status | Evidence |
+|---|---|---|---|
+| 1 | Does Tripwire invoke `tessl skill lint` today? | **Verified — No.** Only `npx --yes tessl@latest skill review --json <workdir>` is called. Lint is not invoked anywhere. | `sandbox/scanners.py:560–585` |
+| 2 | Is `TESSL_TOKEN` available inside the Modal sandbox? | **Verified — Yes.** It is injected via the `tripwire-scan-secrets` Modal secret alongside `SNYK_TOKEN`, `SKILL_SCANNER_LLM_API_KEY`, and others. | `sandbox/scan_app.py:151–157` |
+| 3 | Can the current orchestration dispatch multiple distinct Tessl subcommands within one scan_run? | **Verified — Yes, no orchestration changes needed.** `run_all_scanners()` iterates whatever row-list the group runner returns. The Cisco Skill Scanner (3 rows) and Cisco MCP Scanner (4 rows) already prove this pattern. | `sandbox/scanners.py:1177–1239`, `sandbox/scan_app.py:224–271` |
+| 4 | Does `scan_run_scanners` already support multiple rows per scan_run for the same logical scanner? | **Verified — Yes.** `scanner_source` is a plain `text` column with no uniqueness constraint. Rows are matched for update by `(scan_run_id, scanner_source)` pair. Cisco writes 3 distinct rows per scan_run today. | `db/schema.sql:47–70`, `sandbox/scan_app.py:231–235` |
+| 5 | Is there a per-feature Tessl run-ID column today? | **Verified — No.** `scan_run_scanners` has no `tessl_run_id` or equivalent column. This is net-new in this design. | `db/schema.sql:47–70` |
+| 6 | Does the dashboard UI need a new component for 5 Tessl rows? | **Verified — No.** The `<sc-for list="{{ selectedView.scannersView }}">` loop renders N rows independently. The only Tessl-specific binding (`tesslQuality`) must be scoped to `Tessl: Review (Quality)` only (currently it matches any row with `scanner_source == "Tessl"`). | `Tripwire.dc.html:842–916, 1672–1698` |
+
+**Still Open** (not resolvable by reading the repo — require CLI experimentation or Tessl docs):
+
+| # | Gap | Why it matters |
+|---|---|---|
+| A | Does `tessl review run` / `tessl scenario generate` print a run ID to stdout at trigger time, or only discoverable afterward via `view --last`? | Determines whether the adapter can capture `tessl_run_id` immediately on invocation or must call `view --last --json` after the async job completes. |
+| B | Is `tessl scenario view <id>` (explicit ID form, not `--last`) actually supported? | The cheatsheet only documents `--last`. Needed for cross-feature ID lineage on scenario generation — if unsupported, `tessl_run_id` for that feature has no retrieval path beyond `--last`. |
+| C | Is the agent-assisted scenario generation path (`tessl install tessl-labs/tessl-skill-eval-scenarios`) usable from Tripwire's headless Modal sandbox orchestration? | This is the only documented channel for threading Quality review findings into scenario generation (rule 7b). If it requires an interactive agent prompt, it cannot be scripted. |
+
+---
+
+## (a) Per-Feature State Schema
+
+### Baseline
+
+The existing `scan_run_scanners` table (at `db/schema.sql:47–70`):
+
+```sql
+create table if not exists scan_run_scanners (
+  id             uuid primary key default gen_random_uuid(),
+  scan_run_id    uuid not null references scan_runs(id),
+  scanner_source text not null,
+  status         text not null check (status in (
+    'running','completed','failed',
+    'skipped_missing_credential','unreachable','not_applicable'
+  )),
+  checks_run     integer,
+  detail         text,
+  console_output text,
+  started_at     timestamptz,
+  completed_at   timestamptz
+);
+```
+
+### Status Enum Extension
+
+Replace the 6-state check constraint with the 12-state enum from the design rules. `not_available_yet` is a **UI-only sentinel** — it is never stored in the table (see "Not Available Yet" in section (d) for how the dashboard derives it).
+
+```sql
+ALTER TABLE scan_run_scanners
+  DROP CONSTRAINT scan_run_scanners_status_check,
+  ADD CONSTRAINT scan_run_scanners_status_check CHECK (status IN (
+    'not_started',
+    'needs_setup',
+    'blocked',
+    'queued',
+    'running',
+    'retrying',
+    'interrupted',
+    'completed',
+    'stale',
+    'failed',
+    'timed_out'
+  ));
+```
+
+State meanings (full enum — used consistently across all 5 Tessl rows):
+
+| State | Category | Meaning |
+|---|---|---|
+| `not_started` | Pre-run | Implemented; never triggered for this item |
+| `needs_setup` | Pre-run | Missing config/auth (e.g. `TESSL_TOKEN` absent) |
+| `blocked` | Pre-run | Applies to Eval only, before its first successful run |
+| `queued` | In-flight | Triggered; waiting on sandbox or Tessl server |
+| `running` | In-flight | Actively executing |
+| `retrying` | In-flight | Re-attempt after a prior failure (invocation mechanism parked — see Open Questions) |
+| `interrupted` | Paused | Stopped mid-way with partial state captured in `resume_checkpoint` |
+| `completed` | Terminal (success) | Finished successfully; result persisted |
+| `stale` | Terminal (success, aging) | Completed result is outdated — cache aging, or an upstream dependency changed since. Never auto-cascades. |
+| `failed` | Terminal (error) | Finished with an explicit error |
+| `timed_out` | Terminal (error) | Async run exceeded expected duration with no result |
+
+### New Columns
+
+Four columns are added to support per-feature ID lineage, resumability, and upstream cross-reads:
+
+```sql
+ALTER TABLE scan_run_scanners
+  ADD COLUMN IF NOT EXISTS tessl_run_id       text,
+  ADD COLUMN IF NOT EXISTS tessl_run_id_at    timestamptz,
+  ADD COLUMN IF NOT EXISTS resume_checkpoint  jsonb,
+  ADD COLUMN IF NOT EXISTS upstream_run_ids   jsonb;
+```
+
+| Column | Type | Nullable | Purpose |
+|---|---|---|---|
+| `tessl_run_id` | `text` | YES | The Tessl-side run ID for the last completed or in-flight invocation of this feature. `NULL` until first run produces one. Used for cache-hit check and cross-feature ID lineage reads via `tessl <cmd> view <id> --json`. |
+| `tessl_run_id_at` | `timestamptz` | YES | Timestamp when `tessl_run_id` was last written. Used to detect staleness (e.g. older than cache TTL). |
+| `resume_checkpoint` | `jsonb` | YES | Minimal state blob for interrupted-run resumability. `NULL` when not interrupted. Structure is feature-specific — see section (b) for per-feature shapes. |
+| `upstream_run_ids` | `jsonb` | YES | Map of Tessl run IDs from sibling features read at this feature's start. Populated by the adapter for traceability and cross-feature lineage reads. Example: `{"review_quality": "rev_abc123", "scenario_gen": null}`. `NULL` until populated. |
+
+### Per-Feature `scanner_source` Strings
+
+These exact strings are the row discriminators. Dashboard and adapter must use them verbatim:
+
+| Row | `scanner_source` value |
+|---|---|
+| 1 | `"Tessl: Lint"` |
+| 2 | `"Tessl: Review (Quality)"` |
+| 3 | `"Tessl: Scenario Generation"` |
+| 4 | `"Tessl: Eval"` |
+| 5 | `"Tessl: Review (Security)"` |
+
+### Shared Review Mechanic (Rule 12)
+
+Quality Review and Security Review both use `tessl review run` variants, differing only by judge type. They share a single parameterised adapter function, but write to separate `scan_run_scanners` rows with their distinct `scanner_source`. Each holds its own `tessl_run_id` independently.
+
+Adapter signature (design only — no implementation here):
+
+```
+_run_tessl_review(
+    judge_type: Literal["quality", "security"],
+    workdir: str,
+    workspace: str,
+    prior_run_id: str | None,   # for cache-hit check via tessl_run_id
+    force: bool = False,        # maps to --force flag
+) -> (status, tessl_run_id, checks_run, detail, console_output)
+```
+
+The two rows are fully separate in the DB, dashboard, and state machine — they happen to share implementation, not state.
+
+### Representative Row Shapes
+
+```sql
+-- Tessl: Lint (synchronous/local; no server-side run ID)
+{
+  scan_run_id:       <uuid>,
+  scanner_source:    "Tessl: Lint",
+  status:            "completed",
+  checks_run:        12,
+  detail:            "12 checks — 0 findings",
+  tessl_run_id:      null,
+  tessl_run_id_at:   null,
+  resume_checkpoint: null,
+  upstream_run_ids:  null
+}
+
+-- Tessl: Review (Quality) (async; server-side run ID captured after completion)
+{
+  scanner_source:    "Tessl: Review (Quality)",
+  status:            "completed",
+  tessl_run_id:      "rev_abc123",
+  tessl_run_id_at:   "2026-08-24T10:00:00Z",
+  resume_checkpoint: null,
+  upstream_run_ids:  null      -- quality review has no upstream dependencies
+}
+
+-- Tessl: Scenario Generation (interrupted mid-move; resume_checkpoint populated)
+{
+  scanner_source:    "Tessl: Scenario Generation",
+  status:            "interrupted",
+  tessl_run_id:      null,     -- scenario gen may lack a server-side ID (Coverage Gap B)
+  resume_checkpoint: {"stage": "generated", "scenario_tmp_path": "/tmp/scenarios-xyz/"},
+  upstream_run_ids:  {"review_quality": "rev_abc123"}
+}
+
+-- Tessl: Eval (first run; auto-chained after scenario gen)
+{
+  scanner_source:    "Tessl: Eval",
+  status:            "completed",
+  tessl_run_id:      "eval_xyz789",
+  upstream_run_ids:  {"review_quality": "rev_abc123", "scenario_gen": null}
+  -- scenario_gen tessl_run_id is null due to Coverage Gap B
+}
+
+-- Tessl: Review (Security)
+{
+  scanner_source:    "Tessl: Review (Security)",
+  status:            "completed",
+  tessl_run_id:      "sec_rev_def456",
+  upstream_run_ids:  {"review_quality": "rev_abc123"}
+}
+```
+
+---
+
+## (b) Resume Logic
+
+### Per-Feature Resume Paths
+
+After an interruption, resume using the minimum state needed. The adapter checks `resume_checkpoint` and `tessl_run_id` (via `tessl <cmd> view <id> --json`) before deciding to re-run.
+
+| Feature | Typical interruption point | Resume action | Uses `resume_checkpoint`? |
+|---|---|---|---|
+| **Lint** | During subprocess | Re-run `tessl skill lint` from scratch — deterministic, fast, no server-side state | No |
+| **Review (Quality)** | CLI polling; server job still running | Call `tessl review view --last --json`; if `status=completed` use cached result and persist `tessl_run_id`; else continue polling | No — Tessl CLI natively supports detach/resume |
+| **Scenario Generation** | After `tessl scenario generate`, before or during move to `<plugin>/evals/` | Read `resume_checkpoint.stage`: if `"generated"`, skip generate and move scenarios; if `"moved"`, confirm evals/ contains scenarios and proceed | Yes — fragile hand-off between generate and move |
+| **Eval** | During `--runs 3` polling | Call `tessl eval view --last --json`; if `status=completed` use result; else continue polling | No — same detach/resume as review |
+| **Review (Security)** | CLI polling; server job still running | Same as Review (Quality), parameterised with `judge_type=security` | No |
+
+### `resume_checkpoint` Schema per Feature
+
+Only Scenario Generation requires a checkpoint blob; all other features rely on Tessl CLI's native `view --last` resumability.
+
+```jsonc
+// Tessl: Scenario Generation — possible stage values
+{
+  "stage": "generated",              // tessl scenario generate completed; move not yet done
+  "scenario_tmp_path": "/tmp/…"      // where generated files landed
+}
+// or
+{
+  "stage": "moved"                   // files moved to <plugin>/evals/; eval not yet triggered
+}
+```
+
+### Scenario → Eval Auto-Chain (Rule 4 — First Run Only)
+
+```
+WHEN scenario_gen.status transitions to 'completed'
+  AND resume_checkpoint.stage == 'moved'          -- confirms files are in evals/
+  AND eval.status IN ('blocked', 'not_started')   -- first-run guard
+THEN eval.status → 'queued'                       -- auto-transition within same Run Scan
+```
+
+- If `scenario_gen` ends `failed` or `timed_out` → `eval` stays `blocked`.
+- If `scenario_gen` is **re-run** after `eval` already `completed` → `eval.status` transitions to `stale`. This is **not** an auto-cascade to `queued`: the adapter detects `eval.status == 'completed'` and `scenario_gen.tessl_run_id` changed (or `scenario_gen.tessl_run_id_at` is newer than `eval.completed_at`), then sets `eval.status = 'stale'`. No new eval run fires automatically.
+
+> **⚠ OPEN — Retry Invocation Mechanism**
+>
+> Whether a `failed`, `timed_out`, or `interrupted` Tessl feature row can be retried independently (a single-row Retry affordance on the dashboard) versus only by re-running the full scan is a **product decision explicitly PARKED** for a future pass (see Open Questions). This section describes the resume logic only. The schema (`resume_checkpoint`, `tessl_run_id`, `upstream_run_ids`) and the state model above are designed so either resolution remains possible without a breaking schema change.
+
+---
+
+## (c) ID Lineage Cross-Reads
+
+Each feature that reads from a prior feature's persisted state does so by:
+1. Looking up the prior feature's `tessl_run_id` from its own row's `upstream_run_ids` column (populated at start of the reading feature's run).
+2. Calling `tessl <cmd> view <id> --json` to retrieve full detail.
+
+### 7(a) — Review (Security) ← Review (Quality)
+
+**What is read**: Quality Review's `tessl_run_id` (`rev_abc123`), then `tessl review view rev_abc123 --json` to fetch Quality findings in full.
+
+**Purpose**: UI-level traceability — show Quality findings alongside Security findings so a human reviewer can prioritise which Security issues are most critical. This is **not** a CLI-level behavior change on the security scan itself: `tessl review run security` has no documented flag to alter its scan behavior based on prior findings.
+
+**What is persisted**: `upstream_run_ids: { "review_quality": "rev_abc123" }` on the Security row, written at security-review start.
+
+**Caveat**: If Quality Review has not yet completed (or `tessl_run_id` is null), Security Review proceeds without the cross-read. The `upstream_run_ids` field records `null` for `review_quality`, and the UI shows no linked findings.
+
+### 7(b) — Scenario Generation / Eval ← Review (Quality)
+
+**What is read**: Same Quality Review `tessl_run_id` lookup; `tessl review view <id> --json` to retrieve Quality findings.
+
+**Threading findings into scenario generation**: The **plain CLI form** (`tessl scenario generate <plugin> --workspace <ws>`) has no context-injection flag. To thread Quality findings into scenario generation, the **agent-assisted path** (`tessl install tessl-labs/tessl-skill-eval-scenarios`) is the only documented channel.
+
+**Caveat — agent-assisted path in headless sandbox**: This path is designed around an interactive agent prompt. Whether it can be scripted from Tripwire's headless Modal sandbox orchestration is **unverified** (Coverage Gap C). Until verified, the plain CLI form is used for scenario generation, and the Quality findings are surfaced in the UI as context for human review of the generated scenarios rather than injected into the CLI call.
+
+**What is persisted**: `upstream_run_ids: { "review_quality": "rev_abc123" }` on both the Scenario Generation and Eval rows.
+
+### 7(c) — Extended Cross-Feature Insights (v1 Not Wired)
+
+The following cross-reads would plausibly add value but are **not wired in v1**. They are flagged here for v2 consideration:
+
+| Direction | Potential value | Blocker / note |
+|---|---|---|
+| Eval ← Scenario Generation (`resume_checkpoint`) | Eval could confirm scenarios are in place by reading `resume_checkpoint.stage == "moved"` from the Scenario Gen row before starting, rather than relying solely on a filesystem check. | Not strictly necessary given the auto-chain gate in section (b). Low priority. |
+| Review (Quality) → Lint findings | Lint structural issues (e.g. missing types, naming violations) could help a human reader prioritise which Quality findings to address first. | No CLI mechanism. UI side-by-side display only. Requires UI work. |
+| Review (Security) → Snyk findings (deduplication) | Security Review findings (Snyk-powered via Tessl) could be cross-referenced against Tripwire's existing Snyk row findings to surface duplicates. | Requires either shared findings schema or a post-processing step. Flag for v2 dedup logic. |
+| Any feature → prior scan_run results | On a re-run, adapters could compare new findings against a prior `scan_run_id`'s findings to detect regressions. | Requires querying `scan_run_scanners` across `scan_run_id` values. Not designed in v1. |
+
+---
+
+## (d) UI Flat Rows
+
+### Row Order, Naming, and Initial State
+
+The single existing `"Tessl"` row is replaced by 5 flat sibling rows, in this exact order, in the Scanner Outputs list. No nesting, no expand/collapse group — the same row component used by Cisco's 3 rows.
+
+| Position | `scanner_source` | Day-1 pill | Notes |
+|---|---|---|---|
+| 1 | `Tessl: Lint` | `Not Started` | Implemented when shipped; replaces no existing row |
+| 2 | `Tessl: Review (Quality)` | `Not Started` | Replaces the current single `"Tessl"` row |
+| 3 | `Tessl: Scenario Generation` | `Not Available Yet` | UI placeholder only — not yet implemented |
+| 4 | `Tessl: Eval` | `Not Available Yet` | UI placeholder only — not yet implemented |
+| 5 | `Tessl: Review (Security)` | `Not Available Yet` | UI placeholder only — not yet implemented |
+
+The 5 rows appear as a contiguous block where the single `"Tessl"` row used to be.
+
+### Scanner Outputs Count
+
+The header label (`Scanner Outputs (N)`) updates as follows:
+
+- **Before expansion**: the current count reflects 1 Tessl row among the total.
+- **After expansion (day 1)**: all 5 Tessl rows are counted — including the 3 "Not Available Yet" placeholders — so the count increases by 4 (e.g. `(6) → (10)`). This matches the Cisco precedent: Cisco's rows appear regardless of credential availability (they show `skipped_missing_credential`, not absent).
+
+The dashboard derives the count from the **static constant list** of all 5 expected `scanner_source` strings plus actual DB rows for other scanners, not from the DB row count alone (since "Not Available Yet" rows are never inserted).
+
+> **Open**: whether to include "Not Available Yet" rows in the count is a product/UX decision. The recommendation above (include them, consistent with Cisco) is the default, but is flagged in Open Questions for explicit sign-off.
+
+### "Not Available Yet" Rendering Rules (3 Unbuilt Rows)
+
+The dashboard holds a **static ordered list** of all 5 Tessl `scanner_source` values. For each value absent from the DB rows for the current `scan_run_id`, the `scannersView` map emits a sentinel object with `status: 'not_available_yet'`.
+
+Rendering:
+- Left accent bar: neutral/muted colour (not the status colours used for active rows).
+- Row text: greyed out.
+- Pill: `Not Available Yet` in muted style (no action affordance).
+- No chevron / expand affordance.
+- No `checks_run`, `duration`, or quality-score fields.
+- No `onClick` handler — the row is purely informational.
+
+These rows are **never inserted** into `scan_run_scanners` by the runner. The dashboard synthesises them client-side from the static list.
+
+Implementation touch point: extend the `scannersView` map in `Tripwire.dc.html:1672–1698` to merge the static Tessl list with actual DB rows, emitting sentinel objects for the gaps. The existing `<sc-for>` loop renders them without changes; a conditional style branch on `scv.status === 'not_available_yet'` applies the muted styling.
+
+### Pill Style Map
+
+Extends `scannerStatusColor` and `scannerStatusLabel` in the dashboard JS:
+
+| Status value | Display label | Colour role |
+|---|---|---|
+| `not_available_yet` | Not Available Yet | muted / disabled |
+| `not_started` | Not Started | neutral (grey) |
+| `needs_setup` | Needs Setup | warning (amber) |
+| `blocked` | Blocked | warning (amber) |
+| `queued` | Queued | info (blue) |
+| `running` | Running | info (blue), pulsing |
+| `retrying` | Retrying | info (blue) |
+| `interrupted` | Interrupted | warning (amber) |
+| `completed` | Completed | success (green) |
+| `stale` | Stale | warning (amber) |
+| `failed` | Failed | error (red) |
+| `timed_out` | Timed Out | error (red) |
+
+### `tesslQuality` Binding Scope Fix
+
+The existing `tesslQuality` logic in `Tripwire.dc.html:1672–1698` currently applies to any row whose `scanner_source` matches the old `"Tessl"` string. After expansion, scope it to `scanner_source === "Tessl: Review (Quality)"` only. The quality score badge should not appear on the Lint, Scenario Generation, Eval, or Security Review rows.
+
+---
+
+## Open Questions
+
+### 🚧 PARKED — Retry Invocation Mechanism (Rule 3)
+
+Whether a `failed`, `timed_out`, or `interrupted` Tessl feature row can be **retried independently** (a single-row Retry affordance on the dashboard row) versus only by **re-running the full scan** is a **product decision explicitly deferred** to a future pass. It must not be resolved in this design document.
+
+The schema (`tessl_run_id`, `resume_checkpoint`, `upstream_run_ids`) and the 12-state enum are designed so either resolution is possible without a breaking schema change:
+- A single-row retry would transition the row from its terminal/paused state back to `queued`, leaving sibling rows untouched.
+- A full-scan retry would reset all non-`completed` rows to `not_started`.
+
+Both paths are compatible with the schema above. The retry control (UI affordance and invocation mechanism) is out of scope here.
+
+### Still-Open Coverage Gaps
+
+| # | Gap | Impact if unresolved |
+|---|---|---|
+| A | Does `tessl review run` / `tessl scenario generate` print a run ID to stdout at trigger time, or only via `view --last --json`? | Adapter must choose between capturing ID immediately vs. always polling `view --last` after completion. The latter is safe but slightly less precise if multiple concurrent runs exist. |
+| B | Is `tessl scenario view <id>` (explicit ID form) supported, or only `--last`? | If only `--last` is supported, cross-feature ID lineage for Scenario Generation relies on sequential execution (no concurrent runs) to ensure `--last` references the correct run. Flag as a correctness risk. |
+| C | Is the agent-assisted scenario generation path usable from Tripwire's headless Modal sandbox? | If not, Quality Review findings cannot be threaded into scenario generation programmatically in v1. The fallback is UI-level display of Quality findings alongside the scenario generation row for human reference. |
+| D | Should "Not Available Yet" rows be included in the Scanner Outputs count? | Minor UX decision. Recommendation: include (consistent with Cisco credential-absent rows). Requires explicit product sign-off. |

--- a/docs/design/tessl-5-row-expansion.md
+++ b/docs/design/tessl-5-row-expansion.md
@@ -1,7 +1,7 @@
 # Design: Tessl 5-Row Expansion
 
-**Status**: Draft  
-**Date**: 2026-08-24  
+**Status**: Draft
+**Date**: 2026-08-24
 **Scope**: Design document only — no implementation code. Covers schema extension, resume logic, ID lineage, and UI contract for replacing the single Tessl scanner row with 5 flat capability rows.
 
 ---

--- a/docs/plan/PROGRESS.md
+++ b/docs/plan/PROGRESS.md
@@ -58,6 +58,14 @@ shared code area: slice 18 does not start until the H-wave subcommand lands
 | 17 | H6 | 39 | FE/BE Rearchitecture | Could | 📦 DEFERRED |
 | **0 (next)** | H-ss | **40** | **`tripwire scan --type <skill\|mcp>` filter** | **Must** | 📋 PLANNED |
 | — | G | 18–22 | ATDD closure (parked) | Must | 📋 PLANNED |
+| — | L | 45 | DB Schema Migration (12-state enum + 4 columns) | Must | 📋 PLANNED |
+| — | L | 46 | Tessl: Lint Adapter (Row 1) | Must | 📋 PLANNED |
+| — | L | 47 | Tessl: Review (Quality) Split (Row 2) | Must | 📋 PLANNED |
+| — | L | 48 | "Not Available Yet" Placeholder Rows (Rows 3–5) | Must | 📋 PLANNED |
+| — | L | 49 | Tessl: Scenario Generation + Resume Checkpoint (Row 3) | Should | 📋 PLANNED |
+| — | L | 50 | Tessl: Eval + Auto-Chain (Row 4) | Should | 📋 PLANNED |
+| — | L | 51 | Tessl: Review (Security) (Row 5) | Could | 📋 PLANNED |
+| — | L | 52 | ID Lineage Cross-Reads + UI Side-by-Side | Could | 📋 PLANNED |
 
 ## Quick Status (by group)
 

--- a/docs/plan/README.md
+++ b/docs/plan/README.md
@@ -12,6 +12,10 @@ Horizon A trackers and slice stubs. **Slice files live in wave folders** (execut
 | 6 | [slices/06-F-claim-audit/](slices/06-F-claim-audit/) | Claim audit (15–16) |
 | 7 | [slices/07-G-atdd-closure/](slices/07-G-atdd-closure/) | ATDD closure (18–22) — 📋 planned |
 | 8 | [slices/08-H-frontline-agent-hooks/](slices/08-H-frontline-agent-hooks/) | Frontline agent hooks (23–39) — 📋 plan-only |
+| 9 | [slices/09-I-landing-intro-restyle/](slices/09-I-landing-intro-restyle/) | Landing intro + visual refresh (41, 43) — ✅ |
+| 10 | [slices/10-J-dashboard-data-quality/](slices/10-J-dashboard-data-quality/) | Dashboard data quality fixes (42) — ✅ |
+| 11 | [slices/11-K-docs-ux-plain-language/](slices/11-K-docs-ux-plain-language/) | Docs UX plain language + compaction (44) — 🔀 |
+| 12 | [slices/12-L-tessl-5-row-expansion/](slices/12-L-tessl-5-row-expansion/) | Tessl 5-row expansion (45–52) — 📋 planned · design: [tessl-5-row-expansion.md](../design/tessl-5-row-expansion.md) |
 
 | Tracker | Role |
 |---------|------|

--- a/docs/plan/TRAIL.md
+++ b/docs/plan/TRAIL.md
@@ -260,6 +260,26 @@ prerequisites capability bullets DECIDED, targets pending on this branch.
 |---|------|------|--------|--------|------------|-------|-----------|
 | 44 | [slice-44-docs-ux-plain-language](slices/11-K-docs-ux-plain-language/slice-44-docs-ux-plain-language.md) | Docs UX Plain Language + Compaction (+ Setup/Configure + services diagrams) | Must | 🔀 | 17 | — | ~5 min |
 
+## Wave 12-L — Tessl 5-Row Expansion
+
+Design source: [`docs/design/tessl-5-row-expansion.md`](../design/tessl-5-row-expansion.md)  
+Replaces the single `"Tessl"` scanner row with 5 flat sibling rows following the Cisco 3-row precedent. Slices 45–48 are Must (ship together as a self-contained rollout unit); 49–50 are Should; 51–52 are Could.
+
+**Coverage Gaps that block certain slices**: A (run-ID stdout timing), B (`tessl scenario view <id>` support), C (agent-assisted generation in Modal) — must be resolved before slices 49–52 begin. See `docs/design/tessl-5-row-expansion.md § Open Questions`.
+
+**PARKED**: retry invocation mechanism (single-row vs. full-scan) — schema is designed to support either; product decision deferred.
+
+| # | File | Name | MoSCoW | Status | Depends on | Issue | Read time |
+|---|------|------|--------|--------|------------|-------|-----------|
+| 45 | [slice-45-schema-migration](slices/12-L-tessl-5-row-expansion/slice-45-schema-migration.md) | DB Schema Migration (12-state enum + 4 new columns) | Must | 📋 | 44 | — | ~3 min |
+| 46 | [slice-46-lint-adapter](slices/12-L-tessl-5-row-expansion/slice-46-lint-adapter.md) | Tessl: Lint Adapter (Row 1) | Must | 📋 | 45 | — | ~4 min |
+| 47 | [slice-47-review-quality-split](slices/12-L-tessl-5-row-expansion/slice-47-review-quality-split.md) | Tessl: Review (Quality) Split + `tesslQuality` Scope Fix (Row 2) | Must | 📋 | 45, 46 | — | ~4 min |
+| 48 | [slice-48-not-available-yet-ui](slices/12-L-tessl-5-row-expansion/slice-48-not-available-yet-ui.md) | "Not Available Yet" Placeholder Rows (Rows 3–5) | Must | 📋 | 47 | — | ~3 min |
+| 49 | [slice-49-scenario-generation](slices/12-L-tessl-5-row-expansion/slice-49-scenario-generation.md) | Tessl: Scenario Generation + Resume Checkpoint (Row 3) | Should | 📋 | 47, 48; Gaps A+B | — | ~5 min |
+| 50 | [slice-50-eval-auto-chain](slices/12-L-tessl-5-row-expansion/slice-50-eval-auto-chain.md) | Tessl: Eval + Scenario→Eval Auto-Chain (Row 4) | Should | 📋 | 49 | — | ~4 min |
+| 51 | [slice-51-review-security](slices/12-L-tessl-5-row-expansion/slice-51-review-security.md) | Tessl: Review (Security) Adapter (Row 5) | Could | 📋 | 47 | — | ~3 min |
+| 52 | [slice-52-id-lineage-wiring](slices/12-L-tessl-5-row-expansion/slice-52-id-lineage-wiring.md) | ID Lineage Cross-Reads + UI Side-by-Side Findings | Could | 📋 | 49, 50, 51; Gaps A+B+C | — | ~4 min |
+
 ## Supporting Artifacts
 | File | Status |
 |------|--------|

--- a/docs/plan/TRAIL.md
+++ b/docs/plan/TRAIL.md
@@ -262,7 +262,7 @@ prerequisites capability bullets DECIDED, targets pending on this branch.
 
 ## Wave 12-L — Tessl 5-Row Expansion
 
-Design source: [`docs/design/tessl-5-row-expansion.md`](../design/tessl-5-row-expansion.md)  
+Design source: [`docs/design/tessl-5-row-expansion.md`](../design/tessl-5-row-expansion.md)
 Replaces the single `"Tessl"` scanner row with 5 flat sibling rows following the Cisco 3-row precedent. Slices 45–48 are Must (ship together as a self-contained rollout unit); 49–50 are Should; 51–52 are Could.
 
 **Coverage Gaps that block certain slices**: A (run-ID stdout timing), B (`tessl scenario view <id>` support), C (agent-assisted generation in Modal) — must be resolved before slices 49–52 begin. See `docs/design/tessl-5-row-expansion.md § Open Questions`.

--- a/docs/plan/slices/12-L-tessl-5-row-expansion/slice-45-schema-migration.md
+++ b/docs/plan/slices/12-L-tessl-5-row-expansion/slice-45-schema-migration.md
@@ -1,9 +1,9 @@
 # Slice 45 — DB Schema Migration: Tessl 5-Row Expansion
 
-**Wave**: 12-L  
-**MoSCoW**: Must  
-**Depends on**: 44 (docs current)  
-**Status**: 📋 PLANNED  
+**Wave**: 12-L
+**MoSCoW**: Must
+**Depends on**: 44 (docs current)
+**Status**: 📋 PLANNED
 **Read time**: ~3 min
 
 ## Context
@@ -16,24 +16,24 @@ Design reference: `docs/design/tessl-5-row-expansion.md § (a)`
 
 ### Scenario 1 — Status enum extended
 
-**Given** a Supabase instance with the existing 6-state `scan_run_scanners_status_check` constraint  
-**When** the migration runs  
-**Then** the check constraint is replaced with the 12-state list: `not_started, needs_setup, blocked, queued, running, retrying, interrupted, completed, stale, failed, timed_out`  
-**And** `not_available_yet` is NOT in the constraint (UI-only state, never stored)  
+**Given** a Supabase instance with the existing 6-state `scan_run_scanners_status_check` constraint
+**When** the migration runs
+**Then** the check constraint is replaced with the 12-state list: `not_started, needs_setup, blocked, queued, running, retrying, interrupted, completed, stale, failed, timed_out`
+**And** `not_available_yet` is NOT in the constraint (UI-only state, never stored)
 **And** all existing rows with the old status values remain valid (old values are a subset of new)
 
 ### Scenario 2 — New columns added
 
-**Given** the migration runs successfully  
-**When** the schema is inspected  
-**Then** these columns exist on `scan_run_scanners`: `tessl_run_id text`, `tessl_run_id_at timestamptz`, `resume_checkpoint jsonb`, `upstream_run_ids jsonb`  
-**And** all four columns are nullable  
+**Given** the migration runs successfully
+**When** the schema is inspected
+**Then** these columns exist on `scan_run_scanners`: `tessl_run_id text`, `tessl_run_id_at timestamptz`, `resume_checkpoint jsonb`, `upstream_run_ids jsonb`
+**And** all four columns are nullable
 **And** all existing rows have `NULL` values for the four new columns
 
 ### Scenario 3 — Backward compatibility
 
-**Given** the migration has run  
-**When** the existing Cisco/Snyk/DepShield scanner adapter code writes a row with no new columns  
+**Given** the migration has run
+**When** the existing Cisco/Snyk/DepShield scanner adapter code writes a row with no new columns
 **Then** the insert/update succeeds (new columns default to NULL)
 
 ## Files to touch
@@ -43,6 +43,6 @@ Design reference: `docs/design/tessl-5-row-expansion.md § (a)`
 
 ## Gate evidence fields
 
-`coverage_pct`: N/A (migration only, no new Python code)  
-`complexity_tool`: N/A  
+`coverage_pct`: N/A (migration only, no new Python code)
+`complexity_tool`: N/A
 `doc_audit`: Update `docs/design/tessl-5-row-expansion.md` status to "Schema: Implemented" if applicable

--- a/docs/plan/slices/12-L-tessl-5-row-expansion/slice-45-schema-migration.md
+++ b/docs/plan/slices/12-L-tessl-5-row-expansion/slice-45-schema-migration.md
@@ -1,0 +1,48 @@
+# Slice 45 — DB Schema Migration: Tessl 5-Row Expansion
+
+**Wave**: 12-L  
+**MoSCoW**: Must  
+**Depends on**: 44 (docs current)  
+**Status**: 📋 PLANNED  
+**Read time**: ~3 min
+
+## Context
+
+Tripwire's `scan_run_scanners` table uses a 6-state status enum and has no per-feature Tessl run-ID columns. This slice extends it to support the 12-state enum and 4 new columns required by the Tessl 5-row design.
+
+Design reference: `docs/design/tessl-5-row-expansion.md § (a)`
+
+## Acceptance Criteria (GWT)
+
+### Scenario 1 — Status enum extended
+
+**Given** a Supabase instance with the existing 6-state `scan_run_scanners_status_check` constraint  
+**When** the migration runs  
+**Then** the check constraint is replaced with the 12-state list: `not_started, needs_setup, blocked, queued, running, retrying, interrupted, completed, stale, failed, timed_out`  
+**And** `not_available_yet` is NOT in the constraint (UI-only state, never stored)  
+**And** all existing rows with the old status values remain valid (old values are a subset of new)
+
+### Scenario 2 — New columns added
+
+**Given** the migration runs successfully  
+**When** the schema is inspected  
+**Then** these columns exist on `scan_run_scanners`: `tessl_run_id text`, `tessl_run_id_at timestamptz`, `resume_checkpoint jsonb`, `upstream_run_ids jsonb`  
+**And** all four columns are nullable  
+**And** all existing rows have `NULL` values for the four new columns
+
+### Scenario 3 — Backward compatibility
+
+**Given** the migration has run  
+**When** the existing Cisco/Snyk/DepShield scanner adapter code writes a row with no new columns  
+**Then** the insert/update succeeds (new columns default to NULL)
+
+## Files to touch
+
+- `db/schema.sql` — add ALTER TABLE statements (or integrate into initial CREATE TABLE if schema is always applied fresh)
+- `db/migrations/` — if migration files are tracked separately (verify against repo)
+
+## Gate evidence fields
+
+`coverage_pct`: N/A (migration only, no new Python code)  
+`complexity_tool`: N/A  
+`doc_audit`: Update `docs/design/tessl-5-row-expansion.md` status to "Schema: Implemented" if applicable

--- a/docs/plan/slices/12-L-tessl-5-row-expansion/slice-46-lint-adapter.md
+++ b/docs/plan/slices/12-L-tessl-5-row-expansion/slice-46-lint-adapter.md
@@ -1,9 +1,9 @@
 # Slice 46 — Tessl: Lint Adapter (Row 1)
 
-**Wave**: 12-L  
-**MoSCoW**: Must  
-**Depends on**: 45  
-**Status**: 📋 PLANNED  
+**Wave**: 12-L
+**MoSCoW**: Must
+**Depends on**: 45
+**Status**: 📋 PLANNED
 **Read time**: ~4 min
 
 ## Context
@@ -18,31 +18,31 @@ Design reference: `docs/design/tessl-5-row-expansion.md § (a), (b), (d)`
 
 ### Scenario 1 — Lint row appears in scanner outputs
 
-**Given** a scan_run is triggered for a skill item  
-**When** TESSL_TOKEN is present (or absent — lint is auth-free)  
-**Then** a `scan_run_scanners` row with `scanner_source = "Tessl: Lint"` is written  
+**Given** a scan_run is triggered for a skill item
+**When** TESSL_TOKEN is present (or absent — lint is auth-free)
+**Then** a `scan_run_scanners` row with `scanner_source = "Tessl: Lint"` is written
 **And** `status` is `completed` or `failed` (lint is synchronous; no queued/running states for the row)
 
 ### Scenario 2 — Lint runs without TESSL_TOKEN
 
-**Given** TESSL_TOKEN is absent from the Modal sandbox environment  
-**When** the Tessl group runner executes  
-**Then** the Lint row is still attempted (lint has no auth requirement)  
+**Given** TESSL_TOKEN is absent from the Modal sandbox environment
+**When** the Tessl group runner executes
+**Then** the Lint row is still attempted (lint has no auth requirement)
 **And** Review (Quality) row transitions to `needs_setup` (TESSL_TOKEN absent)
 
 ### Scenario 3 — Lint findings persisted
 
-**Given** lint completes with findings  
-**When** the row is written  
-**Then** `checks_run` reflects the number of lint checks run  
-**And** `detail` contains a human-readable summary  
+**Given** lint completes with findings
+**When** the row is written
+**Then** `checks_run` reflects the number of lint checks run
+**And** `detail` contains a human-readable summary
 **And** `tessl_run_id` is `null` (lint is local/synchronous; no server-side run ID)
 
 ### Scenario 4 — Dashboard renders Lint row
 
-**Given** a scan_run has a `Tessl: Lint` row in the DB  
-**When** the dashboard loads  
-**Then** the Lint row appears at position 1 in the Tessl block  
+**Given** a scan_run has a `Tessl: Lint` row in the DB
+**When** the dashboard loads
+**Then** the Lint row appears at position 1 in the Tessl block
 **And** no `tesslQuality` quality-score badge is shown on the Lint row
 
 ## Files to touch
@@ -52,6 +52,6 @@ Design reference: `docs/design/tessl-5-row-expansion.md § (a), (b), (d)`
 
 ## Gate evidence fields
 
-`coverage_pct`: target matching existing Tessl adapter test coverage  
-`complexity_tool`: ruff/radon on `sandbox/scanners.py`  
+`coverage_pct`: target matching existing Tessl adapter test coverage
+`complexity_tool`: ruff/radon on `sandbox/scanners.py`
 `doc_audit`: `docs/design/tessl-5-row-expansion.md` — verify Lint row status reflects implemented

--- a/docs/plan/slices/12-L-tessl-5-row-expansion/slice-46-lint-adapter.md
+++ b/docs/plan/slices/12-L-tessl-5-row-expansion/slice-46-lint-adapter.md
@@ -1,0 +1,57 @@
+# Slice 46 — Tessl: Lint Adapter (Row 1)
+
+**Wave**: 12-L  
+**MoSCoW**: Must  
+**Depends on**: 45  
+**Status**: 📋 PLANNED  
+**Read time**: ~4 min
+
+## Context
+
+Add `Tessl: Lint` as the first of the 5 new Tessl rows. `tessl skill lint <path>` is deterministic, fast, auth-free, and synchronous — the simplest Tessl capability to implement first.
+
+Today Tripwire does NOT invoke lint (Coverage Gap verified: `sandbox/scanners.py:560–585` only calls `skill review`). This slice adds lint as a separate `scanner_source` row alongside the existing review row.
+
+Design reference: `docs/design/tessl-5-row-expansion.md § (a), (b), (d)`
+
+## Acceptance Criteria (GWT)
+
+### Scenario 1 — Lint row appears in scanner outputs
+
+**Given** a scan_run is triggered for a skill item  
+**When** TESSL_TOKEN is present (or absent — lint is auth-free)  
+**Then** a `scan_run_scanners` row with `scanner_source = "Tessl: Lint"` is written  
+**And** `status` is `completed` or `failed` (lint is synchronous; no queued/running states for the row)
+
+### Scenario 2 — Lint runs without TESSL_TOKEN
+
+**Given** TESSL_TOKEN is absent from the Modal sandbox environment  
+**When** the Tessl group runner executes  
+**Then** the Lint row is still attempted (lint has no auth requirement)  
+**And** Review (Quality) row transitions to `needs_setup` (TESSL_TOKEN absent)
+
+### Scenario 3 — Lint findings persisted
+
+**Given** lint completes with findings  
+**When** the row is written  
+**Then** `checks_run` reflects the number of lint checks run  
+**And** `detail` contains a human-readable summary  
+**And** `tessl_run_id` is `null` (lint is local/synchronous; no server-side run ID)
+
+### Scenario 4 — Dashboard renders Lint row
+
+**Given** a scan_run has a `Tessl: Lint` row in the DB  
+**When** the dashboard loads  
+**Then** the Lint row appears at position 1 in the Tessl block  
+**And** no `tesslQuality` quality-score badge is shown on the Lint row
+
+## Files to touch
+
+- `sandbox/scanners.py` — extend `run_tessl()` to emit a Lint row (follow Cisco pattern: separate invocation, separate `scanner_source` string)
+- `prototypes/dc-dashboard/Tripwire.dc.html` — ensure `tesslQuality` badge is scoped to `"Tessl: Review (Quality)"` only (not `"Tessl: Lint"`)
+
+## Gate evidence fields
+
+`coverage_pct`: target matching existing Tessl adapter test coverage  
+`complexity_tool`: ruff/radon on `sandbox/scanners.py`  
+`doc_audit`: `docs/design/tessl-5-row-expansion.md` — verify Lint row status reflects implemented

--- a/docs/plan/slices/12-L-tessl-5-row-expansion/slice-47-review-quality-split.md
+++ b/docs/plan/slices/12-L-tessl-5-row-expansion/slice-47-review-quality-split.md
@@ -1,9 +1,9 @@
 # Slice 47 — Tessl: Review (Quality) Split + `tesslQuality` Scope Fix (Row 2)
 
-**Wave**: 12-L  
-**MoSCoW**: Must  
-**Depends on**: 45, 46  
-**Status**: 📋 PLANNED  
+**Wave**: 12-L
+**MoSCoW**: Must
+**Depends on**: 45, 46
+**Status**: 📋 PLANNED
 **Read time**: ~4 min
 
 ## Context
@@ -18,30 +18,30 @@ Design reference: `docs/design/tessl-5-row-expansion.md § (a), (d), § Shared R
 
 ### Scenario 1 — Existing quality review row renamed
 
-**Given** a scan_run triggers the Tessl group runner  
-**When** the quality review (`tessl review run`) completes  
-**Then** the `scan_run_scanners` row has `scanner_source = "Tessl: Review (Quality)"`  
-**And** `tessl_run_id` is populated with the Tessl-side run ID (from `tessl review view --last --json`)  
+**Given** a scan_run triggers the Tessl group runner
+**When** the quality review (`tessl review run`) completes
+**Then** the `scan_run_scanners` row has `scanner_source = "Tessl: Review (Quality)"`
+**And** `tessl_run_id` is populated with the Tessl-side run ID (from `tessl review view --last --json`)
 **And** `tessl_run_id_at` is set to the time of capture
 
 ### Scenario 2 — `tesslQuality` badge scoped correctly
 
-**Given** a scan_run has both a `Tessl: Lint` row and a `Tessl: Review (Quality)` row  
-**When** the dashboard renders the scanner outputs list  
-**Then** the quality score badge (`Q 59` style) appears only on the `Tessl: Review (Quality)` row  
+**Given** a scan_run has both a `Tessl: Lint` row and a `Tessl: Review (Quality)` row
+**When** the dashboard renders the scanner outputs list
+**Then** the quality score badge (`Q 59` style) appears only on the `Tessl: Review (Quality)` row
 **And** the Lint row shows no quality badge
 
 ### Scenario 3 — `needs_setup` when TESSL_TOKEN absent
 
-**Given** TESSL_TOKEN is absent from the Modal sandbox  
-**When** the Tessl runner executes  
+**Given** TESSL_TOKEN is absent from the Modal sandbox
+**When** the Tessl runner executes
 **Then** the `Tessl: Review (Quality)` row has `status = "needs_setup"`
 
 ### Scenario 4 — Shared review mechanic parameterised
 
-**Given** both Quality and Security review share the same underlying adapter function  
-**When** the Quality variant is invoked  
-**Then** the parameterised function is called with `judge_type="quality"`  
+**Given** both Quality and Security review share the same underlying adapter function
+**When** the Quality variant is invoked
+**Then** the parameterised function is called with `judge_type="quality"`
 **And** the result is written to the `"Tessl: Review (Quality)"` row only
 
 ## Files to touch
@@ -52,6 +52,6 @@ Design reference: `docs/design/tessl-5-row-expansion.md § (a), (d), § Shared R
 
 ## Gate evidence fields
 
-`coverage_pct`: target ≥ existing Tessl test coverage  
-`complexity_tool`: ruff/radon on `sandbox/scanners.py`  
+`coverage_pct`: target ≥ existing Tessl test coverage
+`complexity_tool`: ruff/radon on `sandbox/scanners.py`
 `doc_audit`: update design doc + user-guide if scanner name appears in user-visible docs

--- a/docs/plan/slices/12-L-tessl-5-row-expansion/slice-47-review-quality-split.md
+++ b/docs/plan/slices/12-L-tessl-5-row-expansion/slice-47-review-quality-split.md
@@ -1,0 +1,57 @@
+# Slice 47 — Tessl: Review (Quality) Split + `tesslQuality` Scope Fix (Row 2)
+
+**Wave**: 12-L  
+**MoSCoW**: Must  
+**Depends on**: 45, 46  
+**Status**: 📋 PLANNED  
+**Read time**: ~4 min
+
+## Context
+
+The current single `"Tessl"` row is renamed to `"Tessl: Review (Quality)"`. The `tesslQuality` badge binding in the dashboard, currently matching any row with `scanner_source == "Tessl"`, is scoped to `"Tessl: Review (Quality)"` only.
+
+This is the highest-value single change: it establishes the row naming contract that all other slices extend, and it makes the dashboard correctly separate Lint (Row 1) from Review (Row 2).
+
+Design reference: `docs/design/tessl-5-row-expansion.md § (a), (d), § Shared Review Mechanic`
+
+## Acceptance Criteria (GWT)
+
+### Scenario 1 — Existing quality review row renamed
+
+**Given** a scan_run triggers the Tessl group runner  
+**When** the quality review (`tessl review run`) completes  
+**Then** the `scan_run_scanners` row has `scanner_source = "Tessl: Review (Quality)"`  
+**And** `tessl_run_id` is populated with the Tessl-side run ID (from `tessl review view --last --json`)  
+**And** `tessl_run_id_at` is set to the time of capture
+
+### Scenario 2 — `tesslQuality` badge scoped correctly
+
+**Given** a scan_run has both a `Tessl: Lint` row and a `Tessl: Review (Quality)` row  
+**When** the dashboard renders the scanner outputs list  
+**Then** the quality score badge (`Q 59` style) appears only on the `Tessl: Review (Quality)` row  
+**And** the Lint row shows no quality badge
+
+### Scenario 3 — `needs_setup` when TESSL_TOKEN absent
+
+**Given** TESSL_TOKEN is absent from the Modal sandbox  
+**When** the Tessl runner executes  
+**Then** the `Tessl: Review (Quality)` row has `status = "needs_setup"`
+
+### Scenario 4 — Shared review mechanic parameterised
+
+**Given** both Quality and Security review share the same underlying adapter function  
+**When** the Quality variant is invoked  
+**Then** the parameterised function is called with `judge_type="quality"`  
+**And** the result is written to the `"Tessl: Review (Quality)"` row only
+
+## Files to touch
+
+- `sandbox/scanners.py` — rename `scanner_source` from `"Tessl"` to `"Tessl: Review (Quality)"`; extract `_run_tessl_review(judge_type, ...)` shared function; capture `tessl_run_id` from `tessl review view --last --json` after async completion
+- `prototypes/dc-dashboard/Tripwire.dc.html` — scope `tesslQuality` binding to `"Tessl: Review (Quality)"` (line ~1686)
+- Any existing tests referencing `scanner_source == "Tessl"` — update to new string
+
+## Gate evidence fields
+
+`coverage_pct`: target ≥ existing Tessl test coverage  
+`complexity_tool`: ruff/radon on `sandbox/scanners.py`  
+`doc_audit`: update design doc + user-guide if scanner name appears in user-visible docs

--- a/docs/plan/slices/12-L-tessl-5-row-expansion/slice-48-not-available-yet-ui.md
+++ b/docs/plan/slices/12-L-tessl-5-row-expansion/slice-48-not-available-yet-ui.md
@@ -1,0 +1,54 @@
+# Slice 48 — "Not Available Yet" Placeholder Rows (Rows 3–5)
+
+**Wave**: 12-L  
+**MoSCoW**: Must  
+**Depends on**: 47  
+**Status**: 📋 PLANNED  
+**Read time**: ~3 min
+
+## Context
+
+From day 1, the Scanner Outputs list shows all 5 Tessl rows. Rows 3–5 (Scenario Generation, Eval, Review (Security)) are not yet implemented and render in a greyed-out "Not Available Yet" state — no action affordance, never inserted into the DB.
+
+This slice adds the static constant list of 5 Tessl `scanner_source` values to the dashboard, and emits sentinel objects for any that are absent from the actual DB rows for the current scan_run.
+
+Design reference: `docs/design/tessl-5-row-expansion.md § (d) — "Not Available Yet" Rendering Rules`
+
+## Acceptance Criteria (GWT)
+
+### Scenario 1 — All 5 Tessl rows visible immediately
+
+**Given** a scan_run has only `Tessl: Lint` and `Tessl: Review (Quality)` rows in the DB (rows 3–5 not implemented yet)  
+**When** the dashboard renders  
+**Then** 5 Tessl rows appear in the Scanner Outputs list, in order: Lint, Review (Quality), Scenario Generation, Eval, Review (Security)  
+**And** rows 3–5 show pill label "Not Available Yet" in muted style  
+**And** rows 3–5 have no chevron/expand affordance, no checks_run count, no duration
+
+### Scenario 2 — Scanner Outputs count includes placeholder rows
+
+**Given** a scan_run with 2 implemented Tessl rows and 3 "Not Available Yet" sentinel rows  
+**When** the dashboard renders the Scanner Outputs header  
+**Then** the count reflects all 5 Tessl rows plus other scanner rows (e.g. `(10)` not `(7)`)
+
+### Scenario 3 — Sentinel rows are never inserted to DB
+
+**Given** the Tessl runner executes (any scan_run)  
+**When** the runner completes  
+**Then** no `scan_run_scanners` row with `scanner_source IN ("Tessl: Scenario Generation", "Tessl: Eval", "Tessl: Review (Security)")` is written  
+**And** the dashboard derives the sentinel rows from the static list, not from the DB
+
+### Scenario 4 — Sentinel rows disappear when feature ships
+
+**Given** a future implementation inserts a `"Tessl: Scenario Generation"` row for a scan_run  
+**When** the dashboard renders  
+**Then** the sentinel placeholder for Scenario Generation is replaced by the real row (with its actual status pill)
+
+## Files to touch
+
+- `prototypes/dc-dashboard/Tripwire.dc.html` — add `TESSL_CAPABILITY_SOURCES` constant (ordered list of 5 strings); extend `scannersView` map to merge DB rows with sentinel objects for missing Tessl sources; add `status === 'not_available_yet'` style branch
+
+## Gate evidence fields
+
+`coverage_pct`: N/A (dashboard JS; no Python tests)  
+`complexity_tool`: N/A  
+`doc_audit`: design doc § (d) count formula and "Not Available Yet" rules — mark as implemented

--- a/docs/plan/slices/12-L-tessl-5-row-expansion/slice-48-not-available-yet-ui.md
+++ b/docs/plan/slices/12-L-tessl-5-row-expansion/slice-48-not-available-yet-ui.md
@@ -1,9 +1,9 @@
 # Slice 48 — "Not Available Yet" Placeholder Rows (Rows 3–5)
 
-**Wave**: 12-L  
-**MoSCoW**: Must  
-**Depends on**: 47  
-**Status**: 📋 PLANNED  
+**Wave**: 12-L
+**MoSCoW**: Must
+**Depends on**: 47
+**Status**: 📋 PLANNED
 **Read time**: ~3 min
 
 ## Context
@@ -18,29 +18,29 @@ Design reference: `docs/design/tessl-5-row-expansion.md § (d) — "Not Availabl
 
 ### Scenario 1 — All 5 Tessl rows visible immediately
 
-**Given** a scan_run has only `Tessl: Lint` and `Tessl: Review (Quality)` rows in the DB (rows 3–5 not implemented yet)  
-**When** the dashboard renders  
-**Then** 5 Tessl rows appear in the Scanner Outputs list, in order: Lint, Review (Quality), Scenario Generation, Eval, Review (Security)  
-**And** rows 3–5 show pill label "Not Available Yet" in muted style  
+**Given** a scan_run has only `Tessl: Lint` and `Tessl: Review (Quality)` rows in the DB (rows 3–5 not implemented yet)
+**When** the dashboard renders
+**Then** 5 Tessl rows appear in the Scanner Outputs list, in order: Lint, Review (Quality), Scenario Generation, Eval, Review (Security)
+**And** rows 3–5 show pill label "Not Available Yet" in muted style
 **And** rows 3–5 have no chevron/expand affordance, no checks_run count, no duration
 
 ### Scenario 2 — Scanner Outputs count includes placeholder rows
 
-**Given** a scan_run with 2 implemented Tessl rows and 3 "Not Available Yet" sentinel rows  
-**When** the dashboard renders the Scanner Outputs header  
+**Given** a scan_run with 2 implemented Tessl rows and 3 "Not Available Yet" sentinel rows
+**When** the dashboard renders the Scanner Outputs header
 **Then** the count reflects all 5 Tessl rows plus other scanner rows (e.g. `(10)` not `(7)`)
 
 ### Scenario 3 — Sentinel rows are never inserted to DB
 
-**Given** the Tessl runner executes (any scan_run)  
-**When** the runner completes  
-**Then** no `scan_run_scanners` row with `scanner_source IN ("Tessl: Scenario Generation", "Tessl: Eval", "Tessl: Review (Security)")` is written  
+**Given** the Tessl runner executes (any scan_run)
+**When** the runner completes
+**Then** no `scan_run_scanners` row with `scanner_source IN ("Tessl: Scenario Generation", "Tessl: Eval", "Tessl: Review (Security)")` is written
 **And** the dashboard derives the sentinel rows from the static list, not from the DB
 
 ### Scenario 4 — Sentinel rows disappear when feature ships
 
-**Given** a future implementation inserts a `"Tessl: Scenario Generation"` row for a scan_run  
-**When** the dashboard renders  
+**Given** a future implementation inserts a `"Tessl: Scenario Generation"` row for a scan_run
+**When** the dashboard renders
 **Then** the sentinel placeholder for Scenario Generation is replaced by the real row (with its actual status pill)
 
 ## Files to touch
@@ -49,6 +49,6 @@ Design reference: `docs/design/tessl-5-row-expansion.md § (d) — "Not Availabl
 
 ## Gate evidence fields
 
-`coverage_pct`: N/A (dashboard JS; no Python tests)  
-`complexity_tool`: N/A  
+`coverage_pct`: N/A (dashboard JS; no Python tests)
+`complexity_tool`: N/A
 `doc_audit`: design doc § (d) count formula and "Not Available Yet" rules — mark as implemented

--- a/docs/plan/slices/12-L-tessl-5-row-expansion/slice-49-scenario-generation.md
+++ b/docs/plan/slices/12-L-tessl-5-row-expansion/slice-49-scenario-generation.md
@@ -1,0 +1,60 @@
+# Slice 49 — Tessl: Scenario Generation Adapter + Resume Checkpoint (Row 3)
+
+**Wave**: 12-L  
+**MoSCoW**: Should  
+**Depends on**: 47, 48  
+**Status**: 📋 PLANNED  
+**Read time**: ~5 min
+
+## Context
+
+Implements the Scenario Generation capability: `tessl scenario generate <plugin> --workspace <ws>` → `tessl scenario download --last` → move scenarios into `<plugin-dir>/evals/`. This is the most fragile step (manual move required; non-deterministic if interrupted). The `resume_checkpoint` jsonb column is essential here.
+
+Design reference: `docs/design/tessl-5-row-expansion.md § (a) resume_checkpoint, § (b) Scenario Generation resume path, § (c) 7(b)`
+
+**Coverage Gap dependency**: If Coverage Gap A (does `tessl scenario generate` print a run ID to stdout?) resolves as No, the adapter must use `tessl scenario view --last` to look up results — and Coverage Gap B (is `view <id>` supported?) affects whether cross-feature lineage can store an explicit ID for scenario gen.
+
+## Acceptance Criteria (GWT)
+
+### Scenario 1 — Successful generation, move, and row update
+
+**Given** Quality Review has completed and `tessl_run_id` is populated  
+**When** Scenario Generation runs  
+**Then** `tessl scenario generate` is invoked; scenarios are downloaded and moved to `<plugin>/evals/`  
+**And** `resume_checkpoint` transitions through `{"stage": "generated"}` → `{"stage": "moved"}` as each step completes  
+**And** final row status is `completed` and `resume_checkpoint` is cleared to `null`
+
+### Scenario 2 — Interrupted after generate, before move
+
+**Given** the runner is interrupted after `generate` succeeds but before the move  
+**When** the runner resumes  
+**Then** `resume_checkpoint.stage == "generated"` is detected  
+**And** the generate step is skipped; only the move is retried
+
+### Scenario 3 — upstream_run_ids populated from Quality Review
+
+**Given** Quality Review's `tessl_run_id` is `"rev_abc123"`  
+**When** Scenario Generation starts  
+**Then** `upstream_run_ids = {"review_quality": "rev_abc123"}` is written to the Scenario Generation row before invocation
+
+### Scenario 4 — Scenario generation failure blocks Eval
+
+**Given** `tessl scenario generate` exits non-zero  
+**When** the runner completes the Scenario Generation step  
+**Then** Scenario Generation row `status = "failed"`  
+**And** Eval row `status` remains `"blocked"` (no auto-chain)
+
+## Files to touch
+
+- `sandbox/scanners.py` — add scenario generation step to `run_tessl()` group runner; implement `resume_checkpoint` write/read; implement `upstream_run_ids` population
+- `sandbox/scan_app.py` — verify `resume_checkpoint` is persisted between Modal function invocations (verify Modal timeout handling)
+
+## Open Question dependency
+
+Coverage Gaps A and B must be resolved before implementing the `tessl_run_id` capture for this feature. If `tessl scenario view <id>` is unsupported (Gap B), store `null` and document the limitation.
+
+## Gate evidence fields
+
+`coverage_pct`: target ≥ 80% for new scenario generation code path  
+`complexity_tool`: ruff/radon on `sandbox/scanners.py`  
+`doc_audit`: design doc § (b) Scenario Generation resume path — mark as implemented

--- a/docs/plan/slices/12-L-tessl-5-row-expansion/slice-49-scenario-generation.md
+++ b/docs/plan/slices/12-L-tessl-5-row-expansion/slice-49-scenario-generation.md
@@ -1,9 +1,9 @@
 # Slice 49 — Tessl: Scenario Generation Adapter + Resume Checkpoint (Row 3)
 
-**Wave**: 12-L  
-**MoSCoW**: Should  
-**Depends on**: 47, 48  
-**Status**: 📋 PLANNED  
+**Wave**: 12-L
+**MoSCoW**: Should
+**Depends on**: 47, 48
+**Status**: 📋 PLANNED
 **Read time**: ~5 min
 
 ## Context
@@ -18,30 +18,30 @@ Design reference: `docs/design/tessl-5-row-expansion.md § (a) resume_checkpoint
 
 ### Scenario 1 — Successful generation, move, and row update
 
-**Given** Quality Review has completed and `tessl_run_id` is populated  
-**When** Scenario Generation runs  
-**Then** `tessl scenario generate` is invoked; scenarios are downloaded and moved to `<plugin>/evals/`  
-**And** `resume_checkpoint` transitions through `{"stage": "generated"}` → `{"stage": "moved"}` as each step completes  
+**Given** Quality Review has completed and `tessl_run_id` is populated
+**When** Scenario Generation runs
+**Then** `tessl scenario generate` is invoked; scenarios are downloaded and moved to `<plugin>/evals/`
+**And** `resume_checkpoint` transitions through `{"stage": "generated"}` → `{"stage": "moved"}` as each step completes
 **And** final row status is `completed` and `resume_checkpoint` is cleared to `null`
 
 ### Scenario 2 — Interrupted after generate, before move
 
-**Given** the runner is interrupted after `generate` succeeds but before the move  
-**When** the runner resumes  
-**Then** `resume_checkpoint.stage == "generated"` is detected  
+**Given** the runner is interrupted after `generate` succeeds but before the move
+**When** the runner resumes
+**Then** `resume_checkpoint.stage == "generated"` is detected
 **And** the generate step is skipped; only the move is retried
 
 ### Scenario 3 — upstream_run_ids populated from Quality Review
 
-**Given** Quality Review's `tessl_run_id` is `"rev_abc123"`  
-**When** Scenario Generation starts  
+**Given** Quality Review's `tessl_run_id` is `"rev_abc123"`
+**When** Scenario Generation starts
 **Then** `upstream_run_ids = {"review_quality": "rev_abc123"}` is written to the Scenario Generation row before invocation
 
 ### Scenario 4 — Scenario generation failure blocks Eval
 
-**Given** `tessl scenario generate` exits non-zero  
-**When** the runner completes the Scenario Generation step  
-**Then** Scenario Generation row `status = "failed"`  
+**Given** `tessl scenario generate` exits non-zero
+**When** the runner completes the Scenario Generation step
+**Then** Scenario Generation row `status = "failed"`
 **And** Eval row `status` remains `"blocked"` (no auto-chain)
 
 ## Files to touch
@@ -55,6 +55,6 @@ Coverage Gaps A and B must be resolved before implementing the `tessl_run_id` ca
 
 ## Gate evidence fields
 
-`coverage_pct`: target ≥ 80% for new scenario generation code path  
-`complexity_tool`: ruff/radon on `sandbox/scanners.py`  
+`coverage_pct`: target ≥ 80% for new scenario generation code path
+`complexity_tool`: ruff/radon on `sandbox/scanners.py`
 `doc_audit`: design doc § (b) Scenario Generation resume path — mark as implemented

--- a/docs/plan/slices/12-L-tessl-5-row-expansion/slice-50-eval-auto-chain.md
+++ b/docs/plan/slices/12-L-tessl-5-row-expansion/slice-50-eval-auto-chain.md
@@ -1,0 +1,64 @@
+# Slice 50 — Tessl: Eval Adapter + Scenario→Eval Auto-Chain (Row 4)
+
+**Wave**: 12-L  
+**MoSCoW**: Should  
+**Depends on**: 49  
+**Status**: 📋 PLANNED  
+**Read time**: ~4 min
+
+## Context
+
+Implements the Eval capability: `tessl eval run <plugin> --runs 3`. The critical design constraint is the first-run auto-chain: Eval must auto-transition from `blocked` → `queued` when Scenario Generation completes with a zero exit code AND scenarios are confirmed in `<plugin>/evals/`. If Scenario Generation is re-run after Eval has already completed once, Eval transitions to `stale` (no auto-cascade).
+
+Design reference: `docs/design/tessl-5-row-expansion.md § (b) auto-chain, § (b) Stale non-cascade`
+
+## Acceptance Criteria (GWT)
+
+### Scenario 1 — First-run auto-chain from Scenario Generation
+
+**Given** Scenario Generation just completed with status `completed`  
+**And** `resume_checkpoint` confirms `stage == "moved"` (scenarios in evals/)  
+**And** Eval row has status `blocked`  
+**When** the auto-chain check runs  
+**Then** Eval row transitions to `queued` within the same Run Scan execution  
+**And** `tessl eval run` is invoked with `--runs 3`
+
+### Scenario 2 — Eval completes; tessl_run_id captured
+
+**Given** `tessl eval run --runs 3` completes  
+**When** results are persisted  
+**Then** `tessl_run_id` is populated (from `tessl eval view --last --json`)  
+**And** `tessl_run_id_at` is set  
+**And** `checks_run` reflects the number of evaluated scenarios  
+**And** `status = "completed"`
+
+### Scenario 3 — Scenario Generation re-run marks Eval as Stale
+
+**Given** Eval has `status = "completed"` with a `tessl_run_id`  
+**When** Scenario Generation is re-run (new `tessl_run_id_at` for Scenario Gen row is newer than Eval's `completed_at`)  
+**Then** Eval row `status` transitions to `"stale"`  
+**And** no new Eval run is triggered automatically
+
+### Scenario 4 — upstream_run_ids populated
+
+**Given** Quality Review's `tessl_run_id` is available  
+**When** Eval starts  
+**Then** `upstream_run_ids = {"review_quality": "<id>", "scenario_gen": null}` is written  
+(scenario_gen ID may be null per Coverage Gap B)
+
+### Scenario 5 — Non-deterministic score handling
+
+**Given** `tessl eval run --runs 3` produces a non-deterministic score (LLM-graded)  
+**When** the result is written  
+**Then** the raw score and run count are persisted in `detail`  
+**And** the row is not marked `failed` solely due to score variance (only failed on non-zero exit)
+
+## Files to touch
+
+- `sandbox/scanners.py` — add eval step to `run_tessl()` group runner; implement auto-chain detection; implement Stale transition logic
+
+## Gate evidence fields
+
+`coverage_pct`: target ≥ 80% for new eval + auto-chain code path  
+`complexity_tool`: ruff/radon on `sandbox/scanners.py`  
+`doc_audit`: design doc § (b) auto-chain and Stale — mark as implemented

--- a/docs/plan/slices/12-L-tessl-5-row-expansion/slice-50-eval-auto-chain.md
+++ b/docs/plan/slices/12-L-tessl-5-row-expansion/slice-50-eval-auto-chain.md
@@ -1,9 +1,9 @@
 # Slice 50 — Tessl: Eval Adapter + Scenario→Eval Auto-Chain (Row 4)
 
-**Wave**: 12-L  
-**MoSCoW**: Should  
-**Depends on**: 49  
-**Status**: 📋 PLANNED  
+**Wave**: 12-L
+**MoSCoW**: Should
+**Depends on**: 49
+**Status**: 📋 PLANNED
 **Read time**: ~4 min
 
 ## Context
@@ -16,41 +16,41 @@ Design reference: `docs/design/tessl-5-row-expansion.md § (b) auto-chain, § (b
 
 ### Scenario 1 — First-run auto-chain from Scenario Generation
 
-**Given** Scenario Generation just completed with status `completed`  
-**And** `resume_checkpoint` confirms `stage == "moved"` (scenarios in evals/)  
-**And** Eval row has status `blocked`  
-**When** the auto-chain check runs  
-**Then** Eval row transitions to `queued` within the same Run Scan execution  
+**Given** Scenario Generation just completed with status `completed`
+**And** `resume_checkpoint` confirms `stage == "moved"` (scenarios in evals/)
+**And** Eval row has status `blocked`
+**When** the auto-chain check runs
+**Then** Eval row transitions to `queued` within the same Run Scan execution
 **And** `tessl eval run` is invoked with `--runs 3`
 
 ### Scenario 2 — Eval completes; tessl_run_id captured
 
-**Given** `tessl eval run --runs 3` completes  
-**When** results are persisted  
-**Then** `tessl_run_id` is populated (from `tessl eval view --last --json`)  
-**And** `tessl_run_id_at` is set  
-**And** `checks_run` reflects the number of evaluated scenarios  
+**Given** `tessl eval run --runs 3` completes
+**When** results are persisted
+**Then** `tessl_run_id` is populated (from `tessl eval view --last --json`)
+**And** `tessl_run_id_at` is set
+**And** `checks_run` reflects the number of evaluated scenarios
 **And** `status = "completed"`
 
 ### Scenario 3 — Scenario Generation re-run marks Eval as Stale
 
-**Given** Eval has `status = "completed"` with a `tessl_run_id`  
-**When** Scenario Generation is re-run (new `tessl_run_id_at` for Scenario Gen row is newer than Eval's `completed_at`)  
-**Then** Eval row `status` transitions to `"stale"`  
+**Given** Eval has `status = "completed"` with a `tessl_run_id`
+**When** Scenario Generation is re-run (new `tessl_run_id_at` for Scenario Gen row is newer than Eval's `completed_at`)
+**Then** Eval row `status` transitions to `"stale"`
 **And** no new Eval run is triggered automatically
 
 ### Scenario 4 — upstream_run_ids populated
 
-**Given** Quality Review's `tessl_run_id` is available  
-**When** Eval starts  
-**Then** `upstream_run_ids = {"review_quality": "<id>", "scenario_gen": null}` is written  
+**Given** Quality Review's `tessl_run_id` is available
+**When** Eval starts
+**Then** `upstream_run_ids = {"review_quality": "<id>", "scenario_gen": null}` is written
 (scenario_gen ID may be null per Coverage Gap B)
 
 ### Scenario 5 — Non-deterministic score handling
 
-**Given** `tessl eval run --runs 3` produces a non-deterministic score (LLM-graded)  
-**When** the result is written  
-**Then** the raw score and run count are persisted in `detail`  
+**Given** `tessl eval run --runs 3` produces a non-deterministic score (LLM-graded)
+**When** the result is written
+**Then** the raw score and run count are persisted in `detail`
 **And** the row is not marked `failed` solely due to score variance (only failed on non-zero exit)
 
 ## Files to touch
@@ -59,6 +59,6 @@ Design reference: `docs/design/tessl-5-row-expansion.md § (b) auto-chain, § (b
 
 ## Gate evidence fields
 
-`coverage_pct`: target ≥ 80% for new eval + auto-chain code path  
-`complexity_tool`: ruff/radon on `sandbox/scanners.py`  
+`coverage_pct`: target ≥ 80% for new eval + auto-chain code path
+`complexity_tool`: ruff/radon on `sandbox/scanners.py`
 `doc_audit`: design doc § (b) auto-chain and Stale — mark as implemented

--- a/docs/plan/slices/12-L-tessl-5-row-expansion/slice-51-review-security.md
+++ b/docs/plan/slices/12-L-tessl-5-row-expansion/slice-51-review-security.md
@@ -1,9 +1,9 @@
 # Slice 51 — Tessl: Review (Security) Adapter (Row 5)
 
-**Wave**: 12-L  
-**MoSCoW**: Could  
-**Depends on**: 47  
-**Status**: 📋 PLANNED  
+**Wave**: 12-L
+**MoSCoW**: Could
+**Depends on**: 47
+**Status**: 📋 PLANNED
 **Read time**: ~3 min
 
 ## Context
@@ -16,30 +16,30 @@ Design reference: `docs/design/tessl-5-row-expansion.md § (a) Shared Review Mec
 
 ### Scenario 1 — Security review row written separately from Quality
 
-**Given** a scan_run has a completed `Tessl: Review (Quality)` row  
-**When** the Tessl runner executes the Security Review step  
-**Then** a separate `scan_run_scanners` row with `scanner_source = "Tessl: Review (Security)"` is written  
+**Given** a scan_run has a completed `Tessl: Review (Quality)` row
+**When** the Tessl runner executes the Security Review step
+**Then** a separate `scan_run_scanners` row with `scanner_source = "Tessl: Review (Security)"` is written
 **And** the Quality Review row is unchanged
 
 ### Scenario 2 — Shared adapter parameterised correctly
 
-**Given** `_run_tessl_review(judge_type="security", ...)` is called  
-**When** the underlying CLI invocation runs  
-**Then** the command is `tessl review run security <path> --workspace <ws>`  
+**Given** `_run_tessl_review(judge_type="security", ...)` is called
+**When** the underlying CLI invocation runs
+**Then** the command is `tessl review run security <path> --workspace <ws>`
 **And** the result is written to the Security row only
 
 ### Scenario 3 — upstream_run_ids links to Quality Review
 
-**Given** Quality Review's `tessl_run_id = "rev_abc123"`  
-**When** Security Review starts  
-**Then** `upstream_run_ids = {"review_quality": "rev_abc123"}` is written to the Security row  
+**Given** Quality Review's `tessl_run_id = "rev_abc123"`
+**When** Security Review starts
+**Then** `upstream_run_ids = {"review_quality": "rev_abc123"}` is written to the Security row
 **And** the dashboard can display Quality findings alongside Security findings for human prioritisation
 
 ### Scenario 4 — Security review proceeds without prior Quality Review
 
-**Given** Quality Review has not yet completed (no `tessl_run_id`)  
-**When** Security Review runs  
-**Then** Security Review proceeds without the cross-read  
+**Given** Quality Review has not yet completed (no `tessl_run_id`)
+**When** Security Review runs
+**Then** Security Review proceeds without the cross-read
 **And** `upstream_run_ids = {"review_quality": null}` is written
 
 ## Files to touch
@@ -49,6 +49,6 @@ Design reference: `docs/design/tessl-5-row-expansion.md § (a) Shared Review Mec
 
 ## Gate evidence fields
 
-`coverage_pct`: target ≥ 80% for security review adapter code  
-`complexity_tool`: ruff/radon on `sandbox/scanners.py`  
+`coverage_pct`: target ≥ 80% for security review adapter code
+`complexity_tool`: ruff/radon on `sandbox/scanners.py`
 `doc_audit`: design doc § (c) 7(a) — mark as implemented

--- a/docs/plan/slices/12-L-tessl-5-row-expansion/slice-51-review-security.md
+++ b/docs/plan/slices/12-L-tessl-5-row-expansion/slice-51-review-security.md
@@ -1,0 +1,54 @@
+# Slice 51 — Tessl: Review (Security) Adapter (Row 5)
+
+**Wave**: 12-L  
+**MoSCoW**: Could  
+**Depends on**: 47  
+**Status**: 📋 PLANNED  
+**Read time**: ~3 min
+
+## Context
+
+Implements `tessl review run security <path> --workspace <ws>` as a separate row from Quality Review. Shares the `_run_tessl_review(judge_type, ...)` parameterised function introduced in slice 47. Populates `upstream_run_ids.review_quality` from the Quality Review row so the UI can show cross-linked findings.
+
+Design reference: `docs/design/tessl-5-row-expansion.md § (a) Shared Review Mechanic, § (c) 7(a)`
+
+## Acceptance Criteria (GWT)
+
+### Scenario 1 — Security review row written separately from Quality
+
+**Given** a scan_run has a completed `Tessl: Review (Quality)` row  
+**When** the Tessl runner executes the Security Review step  
+**Then** a separate `scan_run_scanners` row with `scanner_source = "Tessl: Review (Security)"` is written  
+**And** the Quality Review row is unchanged
+
+### Scenario 2 — Shared adapter parameterised correctly
+
+**Given** `_run_tessl_review(judge_type="security", ...)` is called  
+**When** the underlying CLI invocation runs  
+**Then** the command is `tessl review run security <path> --workspace <ws>`  
+**And** the result is written to the Security row only
+
+### Scenario 3 — upstream_run_ids links to Quality Review
+
+**Given** Quality Review's `tessl_run_id = "rev_abc123"`  
+**When** Security Review starts  
+**Then** `upstream_run_ids = {"review_quality": "rev_abc123"}` is written to the Security row  
+**And** the dashboard can display Quality findings alongside Security findings for human prioritisation
+
+### Scenario 4 — Security review proceeds without prior Quality Review
+
+**Given** Quality Review has not yet completed (no `tessl_run_id`)  
+**When** Security Review runs  
+**Then** Security Review proceeds without the cross-read  
+**And** `upstream_run_ids = {"review_quality": null}` is written
+
+## Files to touch
+
+- `sandbox/scanners.py` — add security review step using `_run_tessl_review(judge_type="security", ...)`
+- `prototypes/dc-dashboard/Tripwire.dc.html` — UI: show Quality findings alongside Security findings when `upstream_run_ids.review_quality` is populated (UI-level traceability, not CLI behavior)
+
+## Gate evidence fields
+
+`coverage_pct`: target ≥ 80% for security review adapter code  
+`complexity_tool`: ruff/radon on `sandbox/scanners.py`  
+`doc_audit`: design doc § (c) 7(a) — mark as implemented

--- a/docs/plan/slices/12-L-tessl-5-row-expansion/slice-52-id-lineage-wiring.md
+++ b/docs/plan/slices/12-L-tessl-5-row-expansion/slice-52-id-lineage-wiring.md
@@ -1,0 +1,55 @@
+# Slice 52 — ID Lineage Cross-Reads + UI Side-by-Side Findings
+
+**Wave**: 12-L  
+**MoSCoW**: Could  
+**Depends on**: 49, 50, 51  
+**Status**: 📋 PLANNED  
+**Read time**: ~4 min
+
+## Context
+
+Wires the full ID lineage cross-read described in the design doc: each downstream feature fetches prior features' findings via `tessl <cmd> view <id> --json` using `upstream_run_ids`, and the dashboard displays cross-linked findings side-by-side for human review prioritisation.
+
+This is a Could slice — the `upstream_run_ids` column is populated by earlier slices (46–51), but the UI rendering and the `tessl review view <id> --json` fetch call are deferred here.
+
+Design reference: `docs/design/tessl-5-row-expansion.md § (c) ID Lineage Cross-Reads`
+
+**Prerequisite**: Coverage Gaps A and B must be resolved. If `tessl scenario view <id>` is not supported (Gap B), the scenario_gen entry in `upstream_run_ids` remains null and this slice documents the gap.
+
+## Acceptance Criteria (GWT)
+
+### Scenario 1 — Security Review fetches Quality findings via run ID
+
+**Given** Security Review's `upstream_run_ids.review_quality = "rev_abc123"`  
+**When** the dashboard renders the Security Review expanded section  
+**Then** Quality findings fetched via `tessl review view rev_abc123 --json` are shown alongside Security findings  
+**And** the fetch result is cached in the expanded view (not re-fetched on every render)
+
+### Scenario 2 — Scenario Generation cross-read documented when CLI injection unavailable
+
+**Given** the agent-assisted scenario generation path (Coverage Gap C) is not usable in Modal sandbox  
+**When** the Scenario Generation row is expanded in the dashboard  
+**Then** the Quality findings are shown as a "context for review" panel (UI-level only)  
+**And** the `upstream_run_ids.review_quality` link is visible so a human can inspect Quality findings before reviewing generated scenarios
+
+### Scenario 3 — Null upstream_run_ids handled gracefully
+
+**Given** a feature has `upstream_run_ids = null` or `upstream_run_ids.review_quality = null`  
+**When** the dashboard renders the expanded section  
+**Then** no cross-linked findings panel appears  
+**And** no error is thrown
+
+## Files to touch
+
+- `prototypes/dc-dashboard/Tripwire.dc.html` — expanded section: add cross-linked findings panel when `scv.upstream_run_ids.review_quality` is populated; fetch `tessl review view <id> --json` via the existing Supabase/API pattern (or store fetched findings in `detail` at scan time)
+- `sandbox/scanners.py` — optionally: fetch and store Quality findings in the Security/Scenario Gen row's `detail` at scan time (simpler than a live UI fetch)
+
+## Open Question dependency
+
+If storing cross-read findings in `detail` at scan time (server side, in the adapter) is preferred over a live dashboard fetch, this slice becomes pure backend work and the dashboard change is minimal. Decide before implementation.
+
+## Gate evidence fields
+
+`coverage_pct`: target ≥ 75% for any new Python fetch code  
+`complexity_tool`: ruff/radon  
+`doc_audit`: design doc § (c) — mark 7(a) and 7(b) as implemented; update 7(c) notes

--- a/docs/plan/slices/12-L-tessl-5-row-expansion/slice-52-id-lineage-wiring.md
+++ b/docs/plan/slices/12-L-tessl-5-row-expansion/slice-52-id-lineage-wiring.md
@@ -1,9 +1,9 @@
 # Slice 52 — ID Lineage Cross-Reads + UI Side-by-Side Findings
 
-**Wave**: 12-L  
-**MoSCoW**: Could  
-**Depends on**: 49, 50, 51  
-**Status**: 📋 PLANNED  
+**Wave**: 12-L
+**MoSCoW**: Could
+**Depends on**: 49, 50, 51
+**Status**: 📋 PLANNED
 **Read time**: ~4 min
 
 ## Context
@@ -20,23 +20,23 @@ Design reference: `docs/design/tessl-5-row-expansion.md § (c) ID Lineage Cross-
 
 ### Scenario 1 — Security Review fetches Quality findings via run ID
 
-**Given** Security Review's `upstream_run_ids.review_quality = "rev_abc123"`  
-**When** the dashboard renders the Security Review expanded section  
-**Then** Quality findings fetched via `tessl review view rev_abc123 --json` are shown alongside Security findings  
+**Given** Security Review's `upstream_run_ids.review_quality = "rev_abc123"`
+**When** the dashboard renders the Security Review expanded section
+**Then** Quality findings fetched via `tessl review view rev_abc123 --json` are shown alongside Security findings
 **And** the fetch result is cached in the expanded view (not re-fetched on every render)
 
 ### Scenario 2 — Scenario Generation cross-read documented when CLI injection unavailable
 
-**Given** the agent-assisted scenario generation path (Coverage Gap C) is not usable in Modal sandbox  
-**When** the Scenario Generation row is expanded in the dashboard  
-**Then** the Quality findings are shown as a "context for review" panel (UI-level only)  
+**Given** the agent-assisted scenario generation path (Coverage Gap C) is not usable in Modal sandbox
+**When** the Scenario Generation row is expanded in the dashboard
+**Then** the Quality findings are shown as a "context for review" panel (UI-level only)
 **And** the `upstream_run_ids.review_quality` link is visible so a human can inspect Quality findings before reviewing generated scenarios
 
 ### Scenario 3 — Null upstream_run_ids handled gracefully
 
-**Given** a feature has `upstream_run_ids = null` or `upstream_run_ids.review_quality = null`  
-**When** the dashboard renders the expanded section  
-**Then** no cross-linked findings panel appears  
+**Given** a feature has `upstream_run_ids = null` or `upstream_run_ids.review_quality = null`
+**When** the dashboard renders the expanded section
+**Then** no cross-linked findings panel appears
 **And** no error is thrown
 
 ## Files to touch
@@ -50,6 +50,6 @@ If storing cross-read findings in `detail` at scan time (server side, in the ada
 
 ## Gate evidence fields
 
-`coverage_pct`: target ≥ 75% for any new Python fetch code  
-`complexity_tool`: ruff/radon  
+`coverage_pct`: target ≥ 75% for any new Python fetch code
+`complexity_tool`: ruff/radon
 `doc_audit`: design doc § (c) — mark 7(a) and 7(b) as implemented; update 7(c) notes


### PR DESCRIPTION
## Summary

- docs(design): Tessl 5-row expansion design + Wave 12-L slice stubs (8 slice stubs, TRAIL.md, PROGRESS.md, plan/README.md)
- chore: fix trailing whitespace (pre-commit hook)

Design source: \`docs/design/tessl-5-row-expansion.md\`

Replaces the single \`"Tessl"\` scanner row with 5 flat sibling rows following the Cisco 3-row precedent. This PR is **design + planning only** — no implementation code.

**What's in this PR:**
- \`docs/design/tessl-5-row-expansion.md\` — full design doc covering:
  - Verified coverage gaps (6 repo-verified facts with file:line citations; 3 still-open CLI gaps named)
  - (a) \`scan_run_scanners\` extension: 12-state enum + 4 new columns (\`tessl_run_id\`, \`tessl_run_id_at\`, \`resume_checkpoint\`, \`upstream_run_ids\`)
  - (b) Per-feature resume logic; scenario→eval first-run auto-chain; Stale non-cascade; retry invocation PARKED
  - (c) ID lineage cross-reads (7a quality→security, 7b quality→scenario/eval, 7c extended notes)
  - (d) 5 flat rows, naming, ordering, pill style map, "Not Available Yet" sentinel rendering
- Wave 12-L slice stubs (45–52) in \`docs/plan/slices/12-L-tessl-5-row-expansion/\`
- \`docs/plan/TRAIL.md\` + \`PROGRESS.md\` + \`plan/README.md\` updated with Wave 12-L

**MoSCoW split:**
- Must: 45 (schema) · 46 (Lint) · 47 (Review Quality split) · 48 (Not Available Yet placeholder UI)
- Should: 49 (Scenario Generation + resume) · 50 (Eval + auto-chain)
- Could: 51 (Review Security) · 52 (ID lineage cross-reads)

**Open / PARKED:** retry invocation mechanism (single-row vs. full-scan) — schema is agnostic; Coverage Gaps A/B/C (CLI behaviour, `scenario view <id>` support, agent-assisted path in Modal sandbox).

## Test Results

| Suite | Result | Coverage |
|-------|--------|----------|
| Python (pytest) | ✅ 345 passed, 0 failed (5.23 s) | 97.03% ≥ 95% threshold |
| ruff | ✅ All checks passed | — |
| mypy | ✅ No issues (7 source files) | — |

## Checklist

- [x] \`./scripts/quality-gates.sh\` passes locally
- [x] New tests added or updated (or change is docs-only)
- [x] Docs updated where applicable
- [x] No secrets or credentials committed