### PR TITLE
feat(slice-47): seed Tessl ID context after Quality Review stamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tessl Review (Quality) run-ID capture (slice 47): `_run_tessl_review(judge_type="quality")`
   runs `tessl review run quality --json --workspace` (replaces deprecated
   `tessl skill review`) then `tessl review view --last --json` to persist
-  `tessl_run_id` + `tessl_run_id_at`. Missing `TESSL_WORKSPACE` → `needs_setup`.
+  `tessl_run_id` + `tessl_run_id_at`. After stamp, `_update_tessl_id_context`
+  sets in-process `ctx["review_quality"]` (GWT-47.5) for slices 49–51.
+  Missing `TESSL_WORKSPACE` → `needs_setup`. Lint stays outside the ID chain.
 - Tessl Lint adapter (slice 46): `run_tessl()` writes a `"Tessl: Lint"` row via
   `npx tessl@latest skill lint` (auth-free, synchronous, no `tessl_run_id`)
   before `"Tessl: Review (Quality)"`. Missing `TESSL_TOKEN` still runs Lint and

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -287,7 +287,8 @@ on the `"Tessl: Review (Quality)"` scanner row only. `"Tessl: Lint"` is a
 separate `scan_run_scanners` row (slice 46 ✅ persist scan_run `a36cad9f`):
 `tessl skill lint`, auth-free, no `tessl_run_id`. Review Quality (slice 47 🔨)
 uses `tessl review run quality --json --workspace` and stamps `tessl_run_id`
-from `tessl review view --last --json`. It is orthogonal to findings and to `risk_score`. **DECIDED (not implemented):** rows 3–5
+from `tessl review view --last --json`, then seeds in-process
+`_TesslIdContext["review_quality"]` for slices 49–51 (GWT-47.5). It is orthogonal to findings and to `risk_score`. **DECIDED (not implemented):** rows 3–5
 (Scenario Generation, Eval, Security Review) — see
 [design/tessl-5-row-expansion.md](./design/tessl-5-row-expansion.md) and slices
 49–51; scenario→eval pipeline is generate → download → `eval run` on disk

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -89,7 +89,8 @@ Reachable through production entry points / config:
 - `"Tessl: Review (Quality)"` run-ID capture — `_run_tessl_review(judge_type="quality")`
   invokes `tessl review run quality --json --workspace` (deprecated `skill review`
   replaced) then `tessl review view --last --json` to persist `tessl_run_id` +
-  `tessl_run_id_at`. Missing `TESSL_WORKSPACE` → `needs_setup`. IMPLEMENTED (unit)
+  `tessl_run_id_at`. `_update_tessl_id_context` seeds `ctx["review_quality"]`
+  in-process (GWT-47.5). Missing `TESSL_WORKSPACE` → `needs_setup`. IMPLEMENTED (unit)
   — `sandbox/scanners.py` (slice 47 🔨, `slice/47-review-quality-split`)
 - Live dashboard latest-state read path — `dashboard_latest_runs` view (one row per
   item) + batched child-table fetches in `tripwire-live.js`; replaces global

--- a/docs/design/tessl-5-row-expansion.md
+++ b/docs/design/tessl-5-row-expansion.md
@@ -288,7 +288,7 @@ ctx: dict[str, str | None] = {
 
 - `_stamp_tessl_run_id(row, run_id)` — slice 47 ✅
 - `_attach_upstream_run_ids(row, ctx, *keys)` — copies selected keys from `ctx` onto row (null for missing keys); slices 49–51
-- `_update_tessl_id_context(ctx, key, run_id)` — sets ctx after stamp; slices 47, 49, 51
+- `_update_tessl_id_context(ctx, key, run_id)` — sets ctx after stamp; slice 47 ✅ (Quality seed); slices 49, 51 reuse
 
 **Rules:**
 

--- a/docs/plan/PROGRESS.md
+++ b/docs/plan/PROGRESS.md
@@ -27,7 +27,7 @@
 | Order | Wave | # | Slice | MoSCoW | Status |
 |------:|-----:|---|-------|--------|--------|
 | 0 (docs) | K | **44** | **Docs UX plain language + compaction** | Must | 🔀 ON BRANCH · [#99](https://github.com/neomatrix369/tripwire/pull/99) · GWT-44.1–44.8 · documentarist APPROVED WITH FOLLOW-ON (DIVIO targets pending) · `slice/44-docs-ux-plain-language` |
-| 0 (active) | L | **47** | **Tessl: Review (Quality) Split (Row 2)** | Must | 🔨 IN PROGRESS · `slice/47-review-quality-split` · GWT-47.1–47.4 |
+| 0 (active) | L | **47** | **Tessl: Review (Quality) Split (Row 2)** | Must | 🔨 IN PROGRESS · `slice/47-review-quality-split` · GWT-47.1–47.5 |
 | 0 (delta) | J | 42 | Dashboard Data Quality — Tessl quality UX + tooltips + plain labels (A9–A13) | Must | ✅ PASSED · [#98](https://github.com/neomatrix369/tripwire/pull/98) |
 | 1 | G | 18 | CLI Operator Evidence Contracts | Must | 📋 PLANNED |
 | 2 | G | 19 | Sandbox Persistence State Contract | Must | 📋 PLANNED |
@@ -260,3 +260,4 @@ Plan", 2026-08-15). Governance blocks *merge*, not prototyping.
 | 2026-08-24 | plan | Tessl scenario/eval slice contract | 49–50 | 📋 PLANNED | Tessl CLI+docs probe: Gap B resolved; slices 49–50 aligned to generate→download→eval run pipeline; slice 52 lineage; TRAIL+design updated. |
 | 2026-08-24 | plan | Tessl ID carry-forward contract | 47–52 | 📋 PLANNED | Design § ID carry-forward + slices 45–52: `_TesslIdContext`, `_attach_upstream_run_ids`, per-row stamp rules; slice 52 depends on 47/49/50/51 populating persisted JSON. |
 | 2026-08-24 | slice/47-review-quality-split | slice-workflow | 47 | 🔨 IN PROGRESS | `_run_tessl_review(quality)` + tessl_run_id via view --last; slice 46 closed ✅ #105 |
+| 2026-08-24 | slice/47-review-quality-split | slice-workflow | 47 | 🔨 IN PROGRESS | GWT-47.5 `_TesslIdContext` seed + `_update_tessl_id_context` after Quality stamp |

--- a/docs/plan/gate-evidence/slice-47.json
+++ b/docs/plan/gate-evidence/slice-47.json
@@ -11,7 +11,8 @@
     "GWT-47.1 — tessl_run_id from review view --last --json; fallback to run JSON id (unit)",
     "GWT-47.2 — tesslInnerQuality still null on Lint (slice 46 regression, dashboard tests)",
     "GWT-47.3 — missing TESSL_TOKEN or TESSL_WORKSPACE → Review needs_setup (unit)",
-    "GWT-47.4 — _run_tessl_review(judge_type=quality) argv is tessl review run quality --json --workspace"
+    "GWT-47.4 — _run_tessl_review(judge_type=quality) argv is tessl review run quality --json --workspace",
+    "GWT-47.5 — _TesslIdContext seeded; ctx[review_quality] set after Quality stamp (unit)"
   ],
   "commands": [
     {
@@ -20,11 +21,11 @@
     },
     {
       "cmd": "uv run pytest sandbox/tests/test_scanners_status.py sandbox/tests/test_ship_path_coverage.py -q",
-      "result": "PASS — 78 tests"
+      "result": "PASS — 81 tests"
     },
     {
       "cmd": "./scripts/quality-gates.sh",
-      "result": "PASS — 245 pytest (sandbox 96.8%, scanners.py 98.3%), 138 CLI tests, ruff/mypy/xenon/bandit/pip-audit/gitleaks green"
+      "result": "PASS — 248 pytest (sandbox 96.8%, scanners.py 98.3%), 138 CLI tests, ruff/mypy/xenon/bandit/pip-audit/gitleaks green"
     }
   ],
   "coverage_pct": "sandbox 96.8% / scanners.py 98.3% (fail-under 95)",

--- a/docs/plan/slices/12-L-tessl-5-row-expansion/slice-47-review-quality-split.md
+++ b/docs/plan/slices/12-L-tessl-5-row-expansion/slice-47-review-quality-split.md
@@ -84,7 +84,7 @@ Design reference: `docs/design/tessl-5-row-expansion.md § (a), (d), § Shared R
 - [x] GWT-47.2 — `tesslInnerQuality` still null on Lint (slice 46 regression)
 - [x] GWT-47.3 — missing token **or** workspace → Review `needs_setup`
 - [x] GWT-47.4 — `_run_tessl_review("quality", …)` argv is `review run quality`
-- [ ] GWT-47.5 — `_TesslIdContext` seeded; `ctx["review_quality"]` set after Quality stamp
+- [x] GWT-47.5 — `_TesslIdContext` seeded; `ctx["review_quality"]` set after Quality stamp
 - [x] `pytest sandbox/tests/test_scanners_status.py sandbox/tests/test_ship_path_coverage.py` exit 0
 - [x] Specification coverage: every GWT clause has ≥1 test
 - [x] `./scripts/quality-gates.sh` passes locally

--- a/sandbox/scanners.py
+++ b/sandbox/scanners.py
@@ -627,6 +627,16 @@ def _stamp_tessl_run_id(row: dict, run_id: str | None) -> None:
     row["tessl_run_id_at"] = datetime.now(UTC).isoformat()
 
 
+def _new_tessl_id_context() -> dict[str, str | None]:
+    """Seed in-process Tessl ID carry-forward (design § ID carry-forward)."""
+    return {"review_quality": None, "scenario_gen": None}
+
+
+def _update_tessl_id_context(ctx: dict[str, str | None], key: str, run_id: str | None) -> None:
+    """Record a step's Tessl run ID for later steps in the same run_tessl() call."""
+    ctx[key] = run_id
+
+
 def _finish_tessl_review(
     judge_type: str, source: str, workspace: str, code, out: str, err: str
 ) -> tuple[float | None, dict]:
@@ -692,7 +702,7 @@ def _parse_tessl_lint_detail(output: str) -> tuple[int | None, str]:
     return checks_run, detail
 
 
-def run_tessl(workdir):
+def run_tessl(workdir, id_context: dict[str, str | None] | None = None):
     """Run Tessl Lint (auth-free) then Review Quality (token-gated) — two rows.
 
     Lint is synchronous and never requires TESSL_TOKEN; it always runs when npx
@@ -701,8 +711,12 @@ def run_tessl(workdir):
 
     Returns (quality_score, [lint_row, review_row]).  quality_score is None when
     Review Quality did not complete successfully.
+
+    id_context is the in-process Tessl ID bag for this invocation (GWT-47.5).
+    Tests inject it to observe carry-forward; production seeds a fresh dict.
     """
     rows: list[dict] = []
+    ctx = id_context if id_context is not None else _new_tessl_id_context()
 
     # --- Tessl: Lint (auth-free, synchronous) ---
     if not _which("npx"):
@@ -734,10 +748,12 @@ def run_tessl(workdir):
     # --- Tessl: Review (Quality) (TESSL_TOKEN + TESSL_WORKSPACE required) ---
     if not os.environ.get("TESSL_TOKEN") or not (os.environ.get("TESSL_WORKSPACE") or "").strip():
         rows.append(_skipped("Tessl: Review (Quality)", reason="needs_setup"))
+        _update_tessl_id_context(ctx, "review_quality", None)
         return None, rows
     workspace = os.environ["TESSL_WORKSPACE"].strip()
     score, review_row = _run_tessl_review("quality", workdir, workspace)
     rows.append(review_row)
+    _update_tessl_id_context(ctx, "review_quality", review_row.get("tessl_run_id"))
     return score, rows
 
 

--- a/sandbox/tests/test_scanners_status.py
+++ b/sandbox/tests/test_scanners_status.py
@@ -6,7 +6,8 @@ Author: swami
 Created: 2026-08-01
 Scope: run_all_scanners overall_status; _unreachable detail truncation;
        _build_console / _truncate_console; on_scanner_done callback relay;
-       _completed console_output passthrough
+       _completed console_output passthrough;
+       Tessl ID context seed after Review Quality (GWT-47.5)
 """
 
 from __future__ import annotations
@@ -799,3 +800,97 @@ def test_run_tessl_without_workspace_emits_review_needs_setup() -> None:
     assert rows[1]["scanner_source"] == "Tessl: Review (Quality)"
     assert rows[1]["status"] == "needs_setup"
     assert all(c[3:5] != ["review", "run"] for c in ran)
+
+
+def test_given_quality_review_completes_when_run_tessl_then_ctx_review_quality_is_stamped_id() -> (
+    None
+):
+    """
+    Scenario: Quality Review run ID seeds in-process Tessl ID context.
+    Slice: 47 — GWT-47.5 _TesslIdContext after Quality stamp
+
+    Given run_tessl initialises ctx with review_quality and scenario_gen as None,
+    When Quality Review completes and stamps tessl_run_id,
+    Then ctx["review_quality"] is that run ID for downstream steps in this invocation,
+    And Lint stays outside the ID chain (no tessl_run_id; no ctx update from Lint).
+    """
+    ### Given
+    ctx = scanners._new_tessl_id_context()
+    lint_output = "4 checks"
+    run_json = '{"score": 64, "id": "rev_from_run"}'
+    view_json = '{"score": 64, "id": "rev_from_view"}'
+
+    ### When
+    with (
+        patch.dict("os.environ", {"TESSL_TOKEN": "t", "TESSL_WORKSPACE": "engteam"}),
+        patch.object(scanners, "_which", return_value="/usr/bin/npx"),
+        patch.object(
+            scanners,
+            "_run",
+            side_effect=[(0, lint_output, ""), (0, run_json, ""), (0, view_json, "")],
+        ),
+    ):
+        _score, rows = scanners.run_tessl("/tmp/fake-skill", id_context=ctx)
+
+    ### Then
+    expected_run_id = "rev_from_view"
+    actual_ctx_quality = ctx["review_quality"]
+    assert actual_ctx_quality == expected_run_id, (
+        f"ctx['review_quality'] should carry the stamped Quality run ID; got {actual_ctx_quality!r}"
+    )
+    assert ctx["scenario_gen"] is None, "scenario_gen must stay None until slice 49 stamps it"
+    lint_row = rows[0]
+    assert lint_row["scanner_source"] == "Tessl: Lint"
+    assert lint_row.get("tessl_run_id") is None, (
+        "Lint is outside the Tessl ID chain — tessl_run_id must stay unset"
+    )
+
+
+def test_given_review_needs_setup_when_run_tessl_then_ctx_review_quality_stays_none() -> None:
+    """
+    Scenario: Missing Review credentials leave Tessl ID context unseeded for Quality.
+    Slice: 47 — GWT-47.5 ctx stays null when Quality does not stamp
+
+    Given TESSL_TOKEN is absent,
+    When run_tessl runs Lint then marks Review needs_setup,
+    Then ctx["review_quality"] stays None,
+    And Lint still has no tessl_run_id.
+    """
+    ### Given
+    ctx = scanners._new_tessl_id_context()
+
+    ### When
+    with (
+        patch.dict("os.environ", {}, clear=True),
+        patch.object(scanners, "_which", return_value="/usr/bin/npx"),
+        patch.object(scanners, "_run", return_value=(0, "1 check", "")),
+    ):
+        _score, rows = scanners.run_tessl("/tmp/fake-skill", id_context=ctx)
+
+    ### Then
+    assert ctx["review_quality"] is None, (
+        "Quality run ID must not be invented when Review is needs_setup"
+    )
+    assert ctx["scenario_gen"] is None, "scenario_gen must stay None in slice 47"
+    assert rows[0].get("tessl_run_id") is None, (
+        "Lint remains outside the ID chain when Review is skipped"
+    )
+
+
+def test_given_empty_state_when_new_tessl_id_context_then_quality_and_scenario_keys_are_none() -> (
+    None
+):
+    """
+    Scenario: Tessl ID context starts with Quality and scenario_gen unset.
+    Slice: 47 — GWT-47.5 _TesslIdContext seed shape
+
+    Given no prior Tessl step has run,
+    When _new_tessl_id_context is called,
+    Then review_quality and scenario_gen are present and None.
+    """
+    ### Given / When
+    actual_ctx = scanners._new_tessl_id_context()
+
+    ### Then
+    expected_ctx = {"review_quality": None, "scenario_gen": None}
+    assert actual_ctx == expected_ctx, f"Seed ctx must be {expected_ctx!r}, got {actual_ctx!r}"


### PR DESCRIPTION
## Summary
- Follow-up to merged [#108](https://github.com/neomatrix369/tripwire/pull/108): implement remaining **GWT-47.5** (`_TesslIdContext` seed after Quality stamp).
- `run_tessl()` initialises in-process Tessl ID context and sets `ctx["review_quality"]` after `_stamp_tessl_run_id`, so slices 49–51 can populate `upstream_run_ids` without a mid-scan Supabase re-query.
- Lint stays outside the ID chain (`tessl_run_id` unset; no ctx update).

## Outcome
Slice 47 GWT-47.1–47.5 now have unit evidence on this branch. `/nw-review` remains the close gate before marking the slice ✅.

## Test plan
- [x] GWT-47.5 — `_TesslIdContext` seeded; `ctx["review_quality"]` set after Quality stamp
- [x] Lint row remains outside the ID chain (`tessl_run_id` null; no ctx update)
- [x] Review `needs_setup` leaves `ctx["review_quality"]` as `None`
- [ ] `/nw-review` APPROVED (mandatory before 🔀 close / ✅)

## Test Results

### Backend
`./scripts/quality-gates.sh` — **248 passed** in 5.15s
Coverage: sandbox **96.8%** / `scanners.py` **98.3%** (fail-under 95)

### CLI
`node --test test/*.test.js` — **138 passed**, 0 failed (7.16s)

## Quality Gates

Gate evidence: `docs/plan/gate-evidence/slice-47.json`

| # | Gate | Status | Detail |
|---|---|---|---|
| 1 | Tests | ✅ passed | 248 pytest + 138 CLI |
| 2 | Line coverage | ✅ 96.8% | sandbox; `scanners.py` 98.3%; fail-under 95 |
| 3 | Branch coverage | ✅ included | pytest-cov branch columns in quality-gates run |
| 4 | Complexity | ✅ xenon exit 0 | `xenon scanners.py` max-absolute D (CI ceiling) |
| 5 | Static analysis | ✅ clean | ruff check/format, mypy, vulture |
| 6 | Regression | ✅ prior Tessl tests green | `test_scanners_status.py` + `test_ship_path_coverage.py` 81 passed |
| 7 | Security scan | ✅ clean | bandit, gitleaks, pip-audit |
| 8 | AT completeness | ✅ GWT-47.5 unit | `_TesslIdContext` seed + Quality stamp + Lint exclusion |
| 9 | Code review | ⏭ pending | `/nw-review` after CI green |

## Checklist

- [x] `./scripts/quality-gates.sh` passes locally
- [x] New tests added or updated (or change is docs-only)
- [x] Docs updated where applicable
- [x] No secrets or credentials committed


Made with [Cursor](https://cursor.com)

<!-- tripwire-complexity:start -->
## Complexity

_Automatically refreshed by CI for product-code changes._

| Scope | Tool | Result |
| --- | --- | --- |
| Python (`sandbox/`) | Radon | highest CC **28** (rank **D**), 281 blocks |
| CLI (`cli/`) | ESLint | 0 function(s) above CC 10 |

<details><summary>Functions above the JavaScript threshold</summary>

- CLI: no functions exceed cyclomatic complexity 10.

</details>
<!-- tripwire-complexity:end -->